### PR TITLE
Modify IQazimuthal.to_workspace()

### DIFF
--- a/tests/unit/drtsans/test_dataobjects.py
+++ b/tests/unit/drtsans/test_dataobjects.py
@@ -535,28 +535,64 @@ class TestIQazimuthal:
         ws = iqaz.to_workspace()
 
         ws_expected = CreateWorkspace(
-            DataX=qx, DataY=I, DataE=E, VerticalAxisValues=qy, VerticalAxisUnit="MomentumTransfer", NSpec=len(qy)
+            DataX=qx,
+            DataY=I,
+            DataE=E,
+            UnitX="MomentumTransfer",
+            VerticalAxisValues=qy,
+            VerticalAxisUnit="MomentumTransfer",
+            NSpec=len(qy),
         )
 
-        assert CompareWorkspaces(ws, ws_expected)
+        assert CompareWorkspaces(ws, ws_expected).Result is True
 
-    def test_to_workspace_2D(self):
-        """test with two-dimensional Qx, Qy, I"""
+    def test_to_workspace_1D_flattened_Q2D(self):
+        """test with one-dimensional Qx, Qy, I where Qx and Qy have been flattened from 2D"""
 
-        i = np.array([[1, 2], [3, 4]])
-        e = np.array([[4, 5], [6, 7]])
-        qx = np.array([[7, 8], [9, 10]])
-        qy = np.array([[11, 12], [12, 13]])
+        i = np.array([1, 2, 3, 4, 5, 6])
+        e = np.array([4, 5, 6, 7, 8, 9])
+        qx = np.array([7, 7, 8, 8, 9, 9])
+        qy = np.array([11, 12, 11, 12, 11, 12])
 
         iqaz = IQazimuthal(i, e, qx, qy)
 
         ws = iqaz.to_workspace()
 
         ws_expected = CreateWorkspace(
-            DataX=qx, DataY=i, DataE=e, NSpec=4, VerticalAxisValues=qy, VerticalAxisUnit="MomentumTransfer"
+            DataX=[7, 8, 9],
+            DataY=[1, 3, 5, 2, 4, 6],
+            DataE=[4, 6, 8, 5, 7, 9],
+            NSpec=2,
+            UnitX="MomentumTransfer",
+            VerticalAxisValues=[11, 12],
+            VerticalAxisUnit="MomentumTransfer",
         )
 
-        assert CompareWorkspaces(ws, ws_expected)
+        assert CompareWorkspaces(ws, ws_expected).Result is True
+
+    def test_to_workspace_2D(self):
+        """test with two-dimensional Qx, Qy, I"""
+
+        i = np.array([[1, 2], [3, 4], [5, 6]])
+        e = np.array([[4, 5], [6, 7], [8, 9]])
+        qx = np.array([[7, 7], [8, 8], [9, 9]])
+        qy = np.array([[11, 12], [11, 12], [11, 12]])
+
+        iqaz = IQazimuthal(i, e, qx, qy)
+
+        ws = iqaz.to_workspace()
+
+        ws_expected = CreateWorkspace(
+            DataX=qx[:, 0],
+            DataY=i.T,
+            DataE=e.T,
+            NSpec=2,
+            UnitX="MomentumTransfer",
+            VerticalAxisValues=qy[0, :],
+            VerticalAxisUnit="MomentumTransfer",
+        )
+
+        assert CompareWorkspaces(ws, ws_expected).Result is True
 
     def test_to_workspace_I2D_Q1D(self):
         """test with two-dimensional I, one-dimensional Qx, Qy"""
@@ -571,10 +607,16 @@ class TestIQazimuthal:
         ws = iqaz.to_workspace()
 
         ws_expected = CreateWorkspace(
-            DataX=qx, DataY=i, DataE=e, Nspec=3, VerticalAxisValues=qy, VerticalAxisUnit="MomentumTransfer"
+            DataX=qx,
+            DataY=i.T,
+            DataE=e.T,
+            Nspec=3,
+            UnitX="MomentumTransfer",
+            VerticalAxisValues=qy,
+            VerticalAxisUnit="MomentumTransfer",
         )
 
-        assert CompareWorkspaces(ws, ws_expected)
+        assert CompareWorkspaces(ws, ws_expected).Result is True
 
 
 class TestTesting:


### PR DESCRIPTION
## Description of work:

The `IQazimuthal` attributes `qx`, `qy`, `intensity` and `error` can be 1D or 2D arrays and the function `IQazimuthal.to_workspace()` had to be updated to handle all cases.

This does not require a release note since it fixes a bug that has not been released.

Check all that apply:
- [ ] ~~added [release notes](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/blob/next/docs/release_notes.rst?ref_type=heads) (if not, provide an explanation in the work description)~~
- [ ] ~~updated documentation~~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Defect 8720: [DRTSANS] CANSAS saving not working with ragged workspaces](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8720)
- Links to related issues or pull requests:

## Manual test for the reviewer
Run [test_EWM367.ipynb](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemOid/com.ibm.team.workitem.Attachment/_t-CpMLvqEe-On74o3FuUZg) and verify that the error message about `SaveNXcanSAS-v1` no longer appears and the canSAS file is saved successfully. Compare the canSAS output file `r27387_AgBeh_Banjo_lambda6p44_2D_main.h5` with the ASCII file `r27387_AgBeh_Banjo_lambda6p44_2D_main.dat`, for example by loading in SasView and plotting.

## Check list for the reviewer
- [ ] [release notes](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/blob/next/docs/release_notes.rst?ref_type=heads) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
