### PR TITLE
Skip time slices for which the transmission calculation fails

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,9 +13,10 @@ User Guide
    :maxdepth: 2
 
    /user/calibration
-   /user/reduction_output
+   /user/corrections/index
    /user/slicing
    /user/binning
+   /user/reduction_output
    /drtsans/reduction_parameters
    /drtsans/reduction_scripts
    release_notes

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,6 +23,7 @@ Release Notes
 
 **Of interest to the User**:
 
+- PR #993: Skip slices with too high transmission error when using time sliced sample transmission run
 - PR #325: Migrates repository from GitLab to GitHub
 - MR #1185: Rename output directory for coherent and incoherent-inelastic corrections as "info"
 - MR #1184: Document wedge binning
@@ -37,7 +38,7 @@ Release Notes
 - MR #1167: Allow separate configurations for inelastic incoherence correction per frame in frame skipping mode
 - MR #1166: Added option to _fitSpectrum to auto-find one wedge and mirror it
 - MR #1162: When reducing `gpsans` data with `direct_beam` scaling, the `direct_beam_scaling` parameter is now logged during
-the reduction process and stored in the output Nexus file at `reduction_information/special_parameters/direct_beam_scaling/value`.
+  the reduction process and stored in the output Nexus file at `reduction_information/special_parameters/direct_beam_scaling/value`.
 - MR #1161: Add a parameters removeAlgorithmHistory to write less data and speed up I/O during reduction
 - MR #1160: Expose pixel detector rescalings to the instrument API's
 - MR #1159: Separate configuration for elastic normalization and inelastic incoherence correction

--- a/docs/user/corrections/index.rst
+++ b/docs/user/corrections/index.rst
@@ -1,0 +1,9 @@
+.. _user.corrections.index:
+
+Corrections
+===========
+
+.. toctree::
+   :maxdepth: 2
+
+   /user/corrections/transmission

--- a/docs/user/corrections/transmission.rst
+++ b/docs/user/corrections/transmission.rst
@@ -7,7 +7,7 @@ The measured intensity must be corrected to account for sample transmission:
 
 .. math::
 
-    I'_{sample}(x,y,\lambda) = \frac{I_{sample}(x,y,\lambda)}{T(\lambda,x,y)}
+    I'_{sample}(x,y,\lambda) = \frac{I_{sample}(x,y,\lambda)}{T(x,y,\lambda)}
 
 The transmission correction is calculated using a transmission run and an empty beam transmission
 run (reference).
@@ -18,44 +18,46 @@ however, this is mostly used for diagnostic purposes.
 
     {
       "sample": {
-        "runNumber": None,
+        "runNumber": 10010,
         "loadOptions": {},
         "thickness": 1.0,
         "transmission": {
-          "runNumber": None,
-          "value": None,
-          "errorTolerance": None
+          "runNumber": null,
+          "value": null,
+          "errorTolerance": null
         }
       },
       "background": {
-        "runNumber": None,
+        "runNumber": null,
         "transmission": {
-          "runNumber": None,
-          "value": None
+          "runNumber": null,
+          "value": null
         }
       },
       "emptyTransmission": {
-        "runNumber": None,
-        "value": None
+        "runNumber": null,
+        "value": null
       },
-      "mmRadiusForTransmission": None,
-      "useTimeSliceTransmission": False,
-      "useThetaDepTransCorrection": True,
+      "mmRadiusForTransmission": null,
+      "useTimeSliceTransmission": false,
+      "useThetaDepTransCorrection": true
     }
 
 Time Slice Transmission (Bio-SANS only)
 ---------------------------------------
 
-When using time slicing (``"useTimeSlice": True``), users can optionally calculate the transmission
+When using time slicing (``"useTimeSlice": true``), users can optionally calculate the transmission
 correction using the time sliced sample run by setting the parameter
-``"useTimeSliceTransmission": True``. The sample transmission run number is ignored when
-``"useTimeSliceTransmission": True``. The time slice transmission option can be used when the sample
+``"useTimeSliceTransmission": true``. The sample transmission run number is ignored when
+``"useTimeSliceTransmission": true``. The time slice transmission option can be used when the sample
 transmission is expected to change over time.
 
 Time slices for which the transmission calculation fails will be skipped. The transmission
 calculation can fail due to all transmission values being NaN or if the transmission error is
 higher than the allowed relative transmission error, which is configurable in the sample
-transmission parameter ``"errorTolerance"`` (default: 0.01).
+transmission parameter ``"errorTolerance"`` (default: 0.01). For example, the last time slice may
+be shorter and, therefore, include fewer counts, resulting in large statistical errors in the
+transmission calculation.
 
 .. code-block:: json
 
@@ -65,18 +67,18 @@ transmission parameter ``"errorTolerance"`` (default: 0.01).
         "loadOptions": {},
         "thickness": 1.0,
         "transmission": {
-          "runNumber": None,
-          "value": None,
+          "runNumber": null,
+          "value": null,
           "errorTolerance": 0.05
         }
       },
       "emptyTransmission": {
         "runNumber": 10005,
-        "value": None
+        "value": null
       },
-      "useTimeSlice": True,
+      "useTimeSlice": true,
       "timeSliceInterval": 100.0,
-      "useTimeSliceTransmission": True,
+      "useTimeSliceTransmission": true
     }
 
 Parameters
@@ -90,20 +92,21 @@ Parameters
      - Description
      - Default
    * - ``"mmRadiusForTransmission"``
-     - Beam radius within which the transmission will be calculated. If ``None``, then the beam
+     - Beam radius within which the transmission will be calculated. If ``null``, then the beam
        radius is calculated from the sample logs.
-     - ``None``
+     - ``null``
    * - ``"useThetaDepTransCorrection"``
-     - If ``True``, a theta dependent transmission correction will be applied, which takes into
+     - If ``true``, a theta dependent transmission correction will be applied, which takes into
        account the effect of the scattering angle on the transmission.
-     - ``True``
+     - ``true``
    * - ``"useTimeSliceTransmission"``
-     - (`Only for Bio-SANS and when` ``"useTimeSlice": True``.) If ``True``, the transmission
+     - (`Only for Bio-SANS and when` ``"useTimeSlice": true``.) If ``true``, the transmission
        correction will be calculated using the time sliced sample run itself instead of a separate
        sample transmission run. This is useful when the sample transmission is expected to change
        over time. Slices with relative transmission error larger than
        ``"transmissionErrorTolerance"`` will be skipped.
-     - ``False``
+     - ``false``
    * - ``"errorTolerance"``
-     - (`Only for Bio-SANS and when` ``"useTimeSlice": True`` `and` ``"useTimeSliceTransmission": True``.) Maximum relative transmission error.
+     - (`Only for Bio-SANS and when` ``"useTimeSlice": true`` `and` ``"useTimeSliceTransmission": true``.)
+       Maximum relative transmission error.
      - 0.01

--- a/docs/user/corrections/transmission.rst
+++ b/docs/user/corrections/transmission.rst
@@ -1,0 +1,109 @@
+.. _user.corrections.transmission:
+
+Transmission
+============
+
+The measured intensity must be corrected to account for sample transmission:
+
+.. math::
+
+    I'_{sample}(x,y,\lambda) = \frac{I_{sample}(x,y,\lambda)}{T(\lambda,x,y)}
+
+The transmission correction is calculated using a transmission run and an empty beam transmission
+run (reference).
+It is possible to specify the transmission value directly in the transmission parameter ``"value"``,
+however, this is mostly used for diagnostic purposes.
+
+.. code-block:: json
+
+    {
+      "sample": {
+        "runNumber": None,
+        "loadOptions": {},
+        "thickness": 1.0,
+        "transmission": {
+          "runNumber": None,
+          "value": None,
+          "errorTolerance": None
+        }
+      },
+      "background": {
+        "runNumber": None,
+        "transmission": {
+          "runNumber": None,
+          "value": None
+        }
+      },
+      "emptyTransmission": {
+        "runNumber": None,
+        "value": None
+      },
+      "mmRadiusForTransmission": None,
+      "useTimeSliceTransmission": False,
+      "useThetaDepTransCorrection": True,
+    }
+
+Time Slice Transmission (Bio-SANS only)
+---------------------------------------
+
+When using time slicing (``"useTimeSlice": True``), users can optionally calculate the transmission
+correction using the time sliced sample run by setting the parameter
+``"useTimeSliceTransmission": True``. The sample transmission run number is ignored when
+``"useTimeSliceTransmission": True``. The time slice transmission option can be used when the sample
+transmission is expected to change over time.
+
+Time slices for which the transmission calculation fails will be skipped. The transmission
+calculation can fail due to all transmission values being NaN or if the transmission error is
+higher than the allowed relative transmission error, which is configurable in the sample
+transmission parameter ``"errorTolerance"`` (default: 0.01).
+
+.. code-block:: json
+
+    {
+      "sample": {
+        "runNumber": 10010,
+        "loadOptions": {},
+        "thickness": 1.0,
+        "transmission": {
+          "runNumber": None,
+          "value": None,
+          "errorTolerance": 0.05
+        }
+      },
+      "emptyTransmission": {
+        "runNumber": 10005,
+        "value": None
+      },
+      "useTimeSlice": True,
+      "timeSliceInterval": 100.0,
+      "useTimeSliceTransmission": True,
+    }
+
+Parameters
+----------
+
+.. list-table::
+   :widths: 25 65 10
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+     - Default
+   * - ``"mmRadiusForTransmission"``
+     - Beam radius within which the transmission will be calculated. If ``None``, then the beam
+       radius is calculated from the sample logs.
+     - ``None``
+   * - ``"useThetaDepTransCorrection"``
+     - If ``True``, a theta dependent transmission correction will be applied, which takes into
+       account the effect of the scattering angle on the transmission.
+     - ``True``
+   * - ``"useTimeSliceTransmission"``
+     - (`Only for Bio-SANS and when` ``"useTimeSlice": True``.) If ``True``, the transmission
+       correction will be calculated using the time sliced sample run itself instead of a separate
+       sample transmission run. This is useful when the sample transmission is expected to change
+       over time. Slices with relative transmission error larger than
+       ``"transmissionErrorTolerance"`` will be skipped.
+     - ``False``
+   * - ``"errorTolerance"``
+     - (`Only for Bio-SANS and when` ``"useTimeSlice": True`` `and` ``"useTimeSliceTransmission": True``.) Maximum relative transmission error.
+     - 0.01

--- a/docs/user/reduction_output.rst
+++ b/docs/user/reduction_output.rst
@@ -5,8 +5,8 @@ Reduction Output
 
 
 
-CANSAS
-------
+canSAS format
+-------------
 
 Collective Action for Nomadic Small-Angle Scatterers (canSAS) provides standards and tools for the small-angle scattering user community. See more at https://www.cansas.org
 

--- a/src/drtsans/configuration/schema/common.json
+++ b/src/drtsans/configuration/schema/common.json
@@ -197,9 +197,13 @@
           },
           "value": {
             "$ref": "common.json#/definitions/transmissionValueTypes"
+          },
+          "errorTolerance": {
+            "$ref": "common.json#/definitions/transmissionValueTypes",
+            "description": "Maximum allowed relative error in the calculated transmission"
           }
         },
-        "maxProperties": 2,
+        "maxProperties": 3,
         "required": ["runNumber", "value"],
         "description": "The transmission for the sample, run number or value (0 < value <=1). Can be empty",
         "examples": ["0.9", 1.0]

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -1407,7 +1407,7 @@ def reduce_single_configuration(
         if time_slice_transmission:
             try:
                 _, sample_trans_ws = _prepare_sample_transmission_ws(raw_sample_ws)
-            except (TransmissionErrorToleranceError, TransmissionNanError) as e:
+            except (ZeroMonitorCountsError, TransmissionErrorToleranceError, TransmissionNanError) as e:
                 logger.warning(f"Skipping slice {sample_name}: {e}.")
                 continue
 

--- a/src/drtsans/mono/normalization.py
+++ b/src/drtsans/mono/normalization.py
@@ -103,8 +103,10 @@ def normalize_by_monitor(input_workspace, output_workspace=None):
 
     Raises
     ------
-    RuntimeError
+    NoMonitorMetadataError
         No monitor metadata found in the sample logs of the input workspace
+    ZeroMonitorCountsError
+        No monitor counts in the input workspace
     """
     metadata_entry_names = [
         "monitor",  # created by load_events

--- a/src/drtsans/mono/transmission.py
+++ b/src/drtsans/mono/transmission.py
@@ -7,7 +7,47 @@ from drtsans.transmission import apply_transmission_correction
 __all__ = ["calculate_transmission", "apply_transmission_correction"]
 
 
-def calculate_transmission(input_sample, input_reference, radius=None, radius_unit="mm", output_workspace=None):
+def calculate_transmission(
+    input_sample,
+    input_reference,
+    radius=None,
+    radius_unit="mm",
+    transmission_error_tolerance=None,
+    output_workspace=None,
+):
+    """
+    Calculate the raw transmission coefficients at zero scattering angle
+    from already prepared sample and reference data.
+
+    Parameters
+    ----------
+    input_sample: str, ~mantid.api.MatrixWorkspace, ~mantid.api.IEventWorkspace
+        Prepared sample workspace (possibly obtained with an attenuated beam)
+    input_reference: str, ~mantid.api.MatrixWorkspace, ~mantid.api.IEventWorkspace
+        Prepared direct beam workspace (possibly obtained with an attenuated beam)
+    radius: float
+        Radius around the beam center for pixel integration, in millimeters.
+        If None, radius will be obtained or calculated using `input_reference` workspace.
+    radius_unit: str
+        Either 'mm' or 'm', and only used in conjunction with option `radius`.
+    transmission_error_tolerance: float | None
+        Maximum relative error for transmission
+    output_workspace: str
+        Name of the output workspace containing the raw transmission values.
+        If None, a hidden random name will be provided.
+
+    Returns
+    -------
+    ~mantid.api.MatrixWorkspace
+        Workspace containing the raw transmission values
+
+    Raises
+    ------
+    TransmissionNanError
+        If all transmission values are NaN
+    TransmissionToleranceError
+        If there is insufficient statistics to calculate the transmission correction
+    """
     if radius is None:
         logger.information("Calculating beam radius from sample logs")
         radius = beam_radius(input_reference, unit="mm")
@@ -17,6 +57,7 @@ def calculate_transmission(input_sample, input_reference, radius=None, radius_un
         input_reference,
         radius,
         radius_unit=radius_unit,
+        transmission_error_tolerance=transmission_error_tolerance,
         output_workspace=output_workspace,
     )
 

--- a/src/drtsans/mono/transmission.py
+++ b/src/drtsans/mono/transmission.py
@@ -31,7 +31,7 @@ def calculate_transmission(
     radius_unit: str
         Either 'mm' or 'm', and only used in conjunction with option `radius`.
     transmission_error_tolerance: float | None
-        Maximum relative error for transmission
+        Maximum relative error for transmission. If None, the error will not be checked.
     output_workspace: str
         Name of the output workspace containing the raw transmission values.
         If None, a hidden random name will be provided.

--- a/src/drtsans/transmission.py
+++ b/src/drtsans/transmission.py
@@ -164,11 +164,13 @@ def calculate_transmission(
         )
         if not np.all(transmission_relative_error < transmission_error_tolerance):
             i_max = np.argmax(transmission_relative_error)
-            error_max = transmission_relative_error[i_max]
-            error_max_transmission = zero_angle_transmission_workspace.readY(0)[non_gap_indexes][i_max]
+            rel_error = transmission_relative_error[i_max]
+            transmission = zero_angle_transmission_workspace.readY(0)[non_gap_indexes][i_max]
+            abs_error = zero_angle_transmission_workspace.readE(0)[non_gap_indexes][i_max]
             raise TransmissionErrorToleranceError(
-                f"Transmission error {error_max:.4f} > transmission error tolerance "
-                f"{transmission_error_tolerance:.4f} (transmission {error_max_transmission:.4f})"
+                f"transmission_error / transmission_value ({abs_error:.4f} / {transmission:.4f} = "
+                f"{rel_error:.4f}) > transmission_relative_error_tolerance "
+                f"({transmission_error_tolerance:.4f})"
             )
 
     # Notify of average transmission value

--- a/src/drtsans/transmission.py
+++ b/src/drtsans/transmission.py
@@ -72,8 +72,8 @@ def calculate_transmission(
         If None, radius will be obtained or calculated using `input_reference` workspace.
     radius_unit: str
         Either 'mm' or 'm', and only used in conjunction with option `radius`.
-    transmission_error_tolerance: float
-        Maximum relative error for transmission
+    transmission_error_tolerance: float | None
+        Maximum relative error for transmission. If None, the error will not be checked.
     output_workspace: str
         Name of the output workspace containing the raw transmission values.
         If None, a hidden random name will be provided.
@@ -85,8 +85,10 @@ def calculate_transmission(
 
     Raises
     ------
+    TransmissionNanError
+        If all transmission values are NaN.
     TransmissionToleranceError
-        If there is insufficient statistics to calculate the transmission correction
+        If there are insufficient statistics to calculate the transmission correction.
     """
     if output_workspace is None:
         output_workspace = mtd.unique_hidden_name()

--- a/src/drtsans/transmission.py
+++ b/src/drtsans/transmission.py
@@ -167,8 +167,8 @@ def calculate_transmission(
             error_max = transmission_relative_error[i_max]
             error_max_transmission = zero_angle_transmission_workspace.readY(0)[non_gap_indexes][i_max]
             raise TransmissionErrorToleranceError(
-                f"Transmission error {error_max} > transmission error tolerance "
-                f"{transmission_error_tolerance} (transmission {error_max_transmission})"
+                f"Transmission error {error_max:.4f} > transmission error tolerance "
+                f"{transmission_error_tolerance:.4f} (transmission {error_max_transmission:.4f})"
             )
 
     # Notify of average transmission value

--- a/tests/integration/drtsans/tof/eqsans/test_transmission.py
+++ b/tests/integration/drtsans/tof/eqsans/test_transmission.py
@@ -38,6 +38,7 @@ from drtsans.tof.eqsans import (
     find_beam_center,
     center_detector,
 )
+from drtsans.transmission import TransmissionNanError
 
 
 @pytest.fixture(scope="module")
@@ -328,7 +329,7 @@ def test_masked_beam_center(datarepo_dir, transmission_fixture, temp_workspace_n
     with amend_config(data_dir=datarepo_dir.eqsans):
         sample_workspace = prepare_data("EQSANS_88975", mask=mask, output_workspace=temp_workspace_name())
         reference_workspace = prepare_data("EQSANS_88973", mask=mask, output_workspace=temp_workspace_name())
-    with pytest.raises(RuntimeError, match=r"Transmission at zero-angle is NaN"):
+    with pytest.raises(TransmissionNanError, match=r"Transmission at zero-angle is NaN"):
         calculate_transmission(sample_workspace, reference_workspace)
     [workspace.delete() for workspace in (sample_workspace, reference_workspace)]
 

--- a/tests/unit/drtsans/test_transmission.py
+++ b/tests/unit/drtsans/test_transmission.py
@@ -2,6 +2,7 @@
 from drtsans.transmission import calculate_transmission, TransmissionErrorToleranceError
 import numpy as np
 import pytest
+import re
 
 # https://docs.mantidproject.org/nightly/algorithms/SetUncertainties-v1.html
 from mantid.simpleapi import SetUncertainties
@@ -308,8 +309,12 @@ def test_transmission_error_tolerance(generic_workspace, clean_workspace):
     assert 1.8 * Isam.extractE().sum() > Iref.extractE().sum()  # shouldn't match
 
     # run the algorithm
-    with pytest.raises(TransmissionErrorToleranceError):
+    with pytest.raises(TransmissionErrorToleranceError) as exc_info:
         calculate_transmission(Isam, Iref, 2.5 * pixel_size, "m", transmission_error_tolerance=0.01)
+
+    assert re.match(
+        "Transmission error 0\.01.* > transmission error tolerance 0.01 \(transmission 0\.55.*\)", str(exc_info.value)
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/drtsans/test_transmission.py
+++ b/tests/unit/drtsans/test_transmission.py
@@ -313,7 +313,9 @@ def test_transmission_error_tolerance(generic_workspace, clean_workspace):
         calculate_transmission(Isam, Iref, 2.5 * pixel_size, "m", transmission_error_tolerance=0.01)
 
     assert re.match(
-        "Transmission error 0.0102 > transmission error tolerance 0.0100 \(transmission 0.5556\)", str(exc_info.value)
+        "transmission_error / transmission_value \(0.0057 / 0.5556 = 0.0102\)"
+        " > transmission_relative_error_tolerance \(0.0100\)",
+        str(exc_info.value),
     )
 
 

--- a/tests/unit/drtsans/test_transmission.py
+++ b/tests/unit/drtsans/test_transmission.py
@@ -313,7 +313,7 @@ def test_transmission_error_tolerance(generic_workspace, clean_workspace):
         calculate_transmission(Isam, Iref, 2.5 * pixel_size, "m", transmission_error_tolerance=0.01)
 
     assert re.match(
-        "Transmission error 0\.01.* > transmission error tolerance 0.01 \(transmission 0\.55.*\)", str(exc_info.value)
+        "Transmission error 0.0102 > transmission error tolerance 0.0100 \(transmission 0.5556\)", str(exc_info.value)
     )
 
 


### PR DESCRIPTION
## Description of work:

Bio-SANS has an option `"useTimeSliceTransmission"` where the transmission correction will be calculated separately for each time slice using the time sliced sample run rather than a separate sample transmission run. Currently, the whole reduction can fail if one time slice (usually the last smaller slice) has insufficient statistics and the transmission calculation results in NaNs. The Bio-SANS IS wants the reduction to proceed without the slice for which the transmission calculation failed.

This PR changes the `RuntimeError` in the transmission calculation to a custom error `TransmissionNanError`. A new sanity check is added for the relative size of the transmission error compared to the transmission value and a custom error `TransmissionErrorToleranceError` is thrown if the value is larger than the sample transmission parameter `"errorTolerance"`. When `"useTimeSliceTransmission"` is used, a time slice will be skipped if `TransmissionNanError` or `TransmissionErrorToleranceError` is thrown. 

- new sample transmission parameter `"errorTolerance"` with default value 0.01
- when using `"useTimeSliceTransmission"`, skip slices with relative transmission error higher than the tolerance or when all transmission values are NaN

Check all that apply:
- [x] added [release notes](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/blob/next/docs/release_notes.rst?ref_type=heads) (if not, provide an explanation in the work description)
- [x] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Defect 8722: [DRTSANS] The time-slicing reduction raises when dividing by the empty transmission value](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8722)
- Links to related issues or pull requests:

## Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/blob/next/docs/release_notes.rst?ref_type=heads) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
