### PR TITLE
Add CI step to build the docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,24 +23,24 @@ jobs:
           environment-file: environment.yml
           lfs: true
           submodules: recursive
-      - name: install additional dependencies
+      - name: Install additional dependencies
         run: |
           echo "installing additional dependencies if cannot be installed from conda"
-      - name: test preparation
+      - name: Test preparation
         run: |
           python -m pip install -e .
           versioningit -vw
           git lfs pull
           git submodule update --init --recursive
-      - name: run unit tests
+      - name: Run unit tests
         run: |
           echo "running unit tests"
           python -m pytest -m "not mount_eqsans" -vv --dist loadscope -n 2 --cov=src --cov-report=xml:unit_test_coverage.xml --cov-report=term --junitxml=unit_test_results.xml tests/unit/
-      - name: run integration tests
+      - name: Run integration tests
         run: |
           echo "running integration tests"
           python -m pytest -m "not mount_eqsans" -vv --dist loadscope -n 2 --cov=src --cov-report=xml:integration_test_coverage.xml --cov-report=term --junitxml=integration_test_results.xml tests/integration/
-      - name: upload coverage to codecov
+      - name: Upload coverage to codecov
         uses: codecov/codecov-action@v5
         if:
           github.actor != 'dependabot[bot]'
@@ -49,7 +49,10 @@ jobs:
           files: |
             unit_test_coverage.xml
             integration_test_coverage.xml
-      - name: build conda package
+      - name: Build the docs
+        run: |
+          cd docs && make html
+      - name: Build conda package
         run: |
           # test that the conda package builds
           cd conda.recipe


### PR DESCRIPTION
## Description of work:

Before the move to GitHub we had a CI step to build the docs. It is useful to get feedback on the docs builds, so let's add it as a step in the CI.

This does not require a release note since it only affects the CI pipeline.

Check all that apply:
- [ ] ~~added [release notes](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/blob/next/docs/release_notes.rst?ref_type=heads) (if not, provide an explanation in the work description)~~
- [ ] ~~updated documentation~~
- [ ] ~~Source added/refactored~~
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~
- [ ] ~~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~~

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/blob/next/docs/release_notes.rst?ref_type=heads) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
