### PR TITLE
Auto find wedge and mirror defect

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,6 +23,7 @@ Release Notes
 
 **Of interest to the User**:
 
+- PR #997: Fix bug causing symmetric auto wedge finding to fail. Add mirrored wedge to auto wedge fit function plot.
 - PR #998: remove the TOF offset that is done by the data aquisition system
 - PR #994: Remove unused module `drtsans/tof/eqsans/reduce.py`
 - PR #993: Skip slices with too high transmission error when using time sliced sample transmission run

--- a/src/drtsans/iq.py
+++ b/src/drtsans/iq.py
@@ -121,14 +121,17 @@ def valid_wedge(min_angle, max_angle) -> List[Tuple[float, float]]:
                 max_angle, min_angle, diff
             )
         )
-    diff = min_angle - max_angle
-    if diff <= 180:
-        raise ValueError(
-            "wedge angle is greater than 180 degrees: {:.1f} - {:.1f} = {:.1f} <= 180".format(
-                min_angle, max_angle, diff
+    else:
+        # max_angle is smaller than min_angle, meaning that the wedge crosses the 270 -> -90 border
+        # Split the wedge into two parts on either side of the border so that all wedges are in the
+        # range [-90,270).
+        diff = 360.0 - (min_angle - max_angle)
+        if diff >= 180:
+            raise ValueError(
+                f"wedge angle (min {min_angle:.1f} max {max_angle:.1f}) is greater than 180 degrees:"
+                f" (360 + {max_angle:.1f}) - {min_angle:.1f} = {diff:.1f} >= 180"
             )
-        )
-    return [(min_angle, 270.1), (-90.1, max_angle)]
+        return [(min_angle, 270.1), (-90.1, max_angle)]
 
 
 def get_wedges(min_angle: float, max_angle: float, symmetric_wedges=True) -> List[Tuple[float, float]]:


### PR DESCRIPTION
## Description of work:

Three changes:

1. Using auto wedges with `"autoSymmetricWedges": true` caused an error in the plotting of peak fit functions, since the number of peaks (two) did not match the number of peaks in the fitting function (one). This is fixed and the mirrored peak is plotted in the same color as the fitted peak but as a dashed line and with a separate label.

`ring_1.png`:
![ring_1](https://github.com/user-attachments/assets/bf3e6827-709a-4d87-9f24-6a87922db273)

2. The test script in the original defect is using `"autoSymmetricWedges": false`. The error is legitimate and is caused by a poor fit giving one angle > 180°, but the error message is confusing since it is checking whether the complementary angle is _less than_ 180°. This is done to simplify checking the size of wedges that overlap the angle position 270° (= -90°) , for example (min, max) = (240, -60) (valid angles are [-90,270) ).
Note that the test script runs without errors if we increase the auto wedge azimuthal angle bin: `"autoWedgeAzimuthalDelta": 2.0`.

Old error:
```
ValueError: wedge angle is greater than 180 degrees: 119.0 - -53.5 = 172.4 <= 180
```
New error:
```
ValueError: wedge angle (min 119.0 max -53.5) is greater than 180 degrees: 360 - (119.0 - -53.5) = 187.6 >= 180
```

3. Add a constraint to the auto wedge peak fitting that peak height must be > 0.

Check all that apply:
- [x] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [x] Source added/refactored
- [ ] ~~Added unit tests~~
- [x] Added integration tests
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Defect 9180: [DRTSANS] Add option to _fitSpectrum to auto-find one wedge and mirror reported as failing](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9180)
- Links to related issues or pull requests:

## Manual test for the reviewer

- Before these changes, run the test script in the EWM story and verify that an error is thrown
- After these changes, run the test script in the EWM story and verify that the reduction runs without errors
- Change the test script in the EWM story to use  `"autoSymmetricWedges": true` and verify that the reduction runs without errors and that the peak fit function plots (`ring_1.png`, `ring_2.png`, etc) include the mirrored peak

## Check list for the reviewer
- [x] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [x] best software practices
    + [x] clearly named variables (better to be verbose in variable names)
    + [x] code comments explaining the intent of code blocks
- [x] All the tests are passing
- [x] The documentation is up to date
- [x] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
