### PR TITLE
Change IQmod to dataclass

### DIFF
--- a/src/drtsans/dataobjects.py
+++ b/src/drtsans/dataobjects.py
@@ -257,6 +257,11 @@ def concatenate(iq_objects):
     return _nary_operation(iq_objects, np.concatenate, unpack=False)
 
 
+# separate arguments with and without defaults into separate base classes to allow
+# child classes to have non-default arguments
+# see https://stackoverflow.com/a/53085935/23095774
+
+
 @dataclass(frozen=True)
 class _I1DBase:
     intensity: np.ndarray | list

--- a/src/drtsans/save_ascii.py
+++ b/src/drtsans/save_ascii.py
@@ -1,5 +1,6 @@
 # standard imports
 import os
+from dataclasses import asdict
 
 # local imports
 from drtsans.dataobjects import IQazimuthal
@@ -27,7 +28,7 @@ def save_ascii_binned_1D(filename: str, title, *args, **kwargs):
         intensity, error, mod_q, delta_mod_q - 1D numpy arrays of the same length, output from 1D binning
     """
     try:
-        kwargs.update(args[0]._asdict())
+        kwargs.update(asdict(args[0]))
     except AttributeError:
         pass
     # Read the value of skip_nan from kwargs or True as default
@@ -98,7 +99,7 @@ def save_ascii_binned_2D(filename: str, title, *args, **kwargs):
         intensity, error, qx, qy, delta_qx, delta_qy - 1D numpy arrays of the same length, output from 1D binning
     """
     try:
-        kwargs = args[0]._asdict()
+        kwargs = asdict(args[0])
     except AttributeError:
         pass
     # make everything a 1d array

--- a/src/drtsans/tof/eqsans/momentum_transfer.py
+++ b/src/drtsans/tof/eqsans/momentum_transfer.py
@@ -1,5 +1,6 @@
 import numpy as np
 from collections import namedtuple
+from dataclasses import asdict
 
 # https://github.com/neutrons/drtsans/blob/next/src/drtsans/momentum_transfer.py
 import drtsans.momentum_transfer
@@ -275,12 +276,11 @@ def split_by_frame(input_workspace, *args, **kwargs):
     except AttributeError:
         input_type = None
     # transform args to dictionary
-    # FIXME - It is better to use a different variable name for kwargs as it may shadow method input
     try:
-        kwargs = args[0]._asdict()
+        i_of_q = asdict(args[0])
     except AttributeError:
         pass
-    keys = kwargs.keys()
+    keys = i_of_q.keys()
     info += f"Argument keys = {list(keys)}\n"
 
     # get the wavelengths for each frame
@@ -309,12 +309,12 @@ def split_by_frame(input_workspace, *args, **kwargs):
     output_list = []
     for wl_min, wl_max in frames:
         output = dict()
-        wavelength = kwargs["wavelength"]
+        wavelength = i_of_q["wavelength"]
         # use only data between the given wavelengths
         kept_data_indexes = np.logical_and(np.greater_equal(wavelength, wl_min), np.less_equal(wavelength, wl_max))
         # filter each data/key
         for k in keys:
-            output[k] = kwargs[k][kept_data_indexes]
+            output[k] = i_of_q[k][kept_data_indexes]
         # create the namedtuple from a dictionary
         if input_type is not None:
             output_list.append(input_type(**output))

--- a/tests/unit/drtsans/test_momentum_transfer.py
+++ b/tests/unit/drtsans/test_momentum_transfer.py
@@ -81,13 +81,15 @@ def test_convert_to_mod_q(generic_workspace, clean_workspace):
     MaskDetectors(ws, WorkspaceIndexList=[2])
     # For every detector pixel, calculate the intensity, intensity error, Q-value, it's error, and the associated
     # vawelength.
-    intensity, error, modq, dq, lam = convert_to_q(ws, mode="scalar")
-    assert intensity == pytest.approx([10, 20, 40], abs=1e-5)
-    assert error == pytest.approx([1, 2, 4], abs=1e-5)
+    result = convert_to_q(ws, mode="scalar")
+    assert result.intensity == pytest.approx([10, 20, 40], abs=1e-5)
+    assert result.error == pytest.approx([1, 2, 4], abs=1e-5)
     # we are not passing any resolution function as argument 'resolution_function' in function
     # 'convert_to_q'. Thus, we assume infinite precision and the error in Q is therefore zero.
-    assert dq == pytest.approx([0, 0, 0], abs=1e-5)
-    assert lam == pytest.approx([6, 6, 6], abs=1e-5)  # 6 Angstroms is the middle point of the bin [5.9, 6.1]
+    assert result.delta_mod_q == pytest.approx([0, 0, 0], abs=1e-5)
+    assert result.wavelength == pytest.approx(
+        [6, 6, 6], abs=1e-5
+    )  # 6 Angstroms is the middle point of the bin [5.9, 6.1]
 
     # All detector pixels subtend the same scattering angle. Detectors are located at coordinates
     # (x, y, z) = (+-0.5, +-0.5, 5.0)
@@ -97,7 +99,7 @@ def test_convert_to_mod_q(generic_workspace, clean_workspace):
     # assert the Q value for each detector pixel. Again, all Q-values are the same because all two_theta values
     # are the same for all three unmasked detector pixels
     q = 4.0 * np.pi * np.sin(two_theta * 0.5) / 6.0
-    assert modq == pytest.approx([q, q, q], abs=1e-5)
+    assert result.mod_q == pytest.approx([q, q, q], abs=1e-5)
 
     # test namedtuple result and resolution
     # Function fake_resolution1 returns the workspace index of the pixel detector as the error of


### PR DESCRIPTION
## Description of work:

As part of harmonizing the annular binning output, we want to create a base class for 1D intensity profiles, from which `IQmod` and the new class `I1Dannular` will inherit. This is a draft PR to explore changing `IQmod` from `namedtuple` to `dataclass`, since inheriting from a `namedtuple` does not easily allow adding additional attributes. By using `dataclass` with the `frozen` flag, we can emulate immutability like for `namedtuple`.

Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Story 364: [DRTSANS] Harmonizing the output style and content of 1D intensity profile obtained from annular binning](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=364)
- Links to related issues or pull requests:

## Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
