### PR TITLE
Rename azimuthal angle from `theta` to `phi`

### DIFF
--- a/src/drtsans/iq.py
+++ b/src/drtsans/iq.py
@@ -527,9 +527,9 @@ def select_i_of_q_by_wedge(i_of_q, min_wedge_angle, max_wedge_angle):
     i_of_q : ~drtsans.dataobjects.IQazimuthal
          "intensity": intensity, "error": sigma(I), "qx": qx, "qy": qy, "delta_qx": dqx, "delta_qy", dqy
     min_wedge_angle : float
-        minimum value of theta/azimuthal angle for wedge
+        minimum value of phi/azimuthal angle for wedge
     max_wedge_angle : float
-        maximum value of theta/azimuthal angle for wedge
+        maximum value of phi/azimuthal angle for wedge
 
     Returns
     -------
@@ -601,7 +601,7 @@ def _toQmodAndAzimuthal(
     return data.intensity.ravel(), data.error.ravel(), q, dq, azimuthal
 
 
-def bin_annular_into_q1d(i_of_q, theta_bin_params, q_min=0.001, q_max=0.4, method=BinningMethod.NOWEIGHT):
+def bin_annular_into_q1d(i_of_q, phi_bin_params, q_min=0.001, q_max=0.4, method=BinningMethod.NOWEIGHT):
     """Annular 1D binning
 
     Calculates: I(azimuthal), sigma I and dazmuthal by assigning pixels to proper azimuthal angle bins
@@ -612,13 +612,13 @@ def bin_annular_into_q1d(i_of_q, theta_bin_params, q_min=0.001, q_max=0.4, metho
     ----------
     i_of_q :  ~drtsans.dataobjects.IQazimuthal
         I(Qx, Qy), sigma I(Qx, Qy), Qx, Qy, dQx and dQy
-    theta_bin_params : ~drtsans.BinningParams
-        binning parameters on annular angle 'theta'
+    phi_bin_params : ~drtsans.BinningParams
+        binning parameters on annular angle 'phi'
 
-        theta_min : float
-            minimum value of theta/azimuthal angle
-        theta_max : float
-            maximum value of theta/azimuthal angle
+        phi_min : float
+            minimum value of phi/azimuthal angle
+        phi_max : float
+            maximum value of phi/azimuthal angle
         bins : int or sequence of scalars, optional
             See `scipy.stats.binned_statistic`.
             If `bins` is an int, it defines the number of equal-width bins in
@@ -641,19 +641,17 @@ def bin_annular_into_q1d(i_of_q, theta_bin_params, q_min=0.001, q_max=0.4, metho
     drtsans.dataobjects.IQmod
         Annular-binned I(azimuthal) in 1D
     """
-    # Determine azimuthal angle bins (i.e., theta bins)
-    theta_bins = determine_1d_linear_bins(theta_bin_params.min, theta_bin_params.max, theta_bin_params.bins)
-    if theta_bins.centers.min() < 0.0 or theta_bins.centers.max() > 360.0:
-        msg = "must specify range 0<=theta<=360deg found {}<=theta<={}deg".format(
-            theta_bin_params.min, theta_bin_params.max
-        )
+    # Determine azimuthal angle bins (i.e., phi bins)
+    phi_bins = determine_1d_linear_bins(phi_bin_params.min, phi_bin_params.max, phi_bin_params.bins)
+    if phi_bins.centers.min() < 0.0 or phi_bins.centers.max() > 360.0:
+        msg = "must specify range 0<=phi<=360deg found {}<=phi<={}deg".format(phi_bin_params.min, phi_bin_params.max)
         raise ValueError(msg)
 
     # Check whether input I(Q) meets assumptions
     check_iq_for_binning(i_of_q)
 
     # convert the data to q and azimuthal angle
-    intensity, error, q_array, dq_array, theta_array = _toQmodAndAzimuthal(i_of_q)
+    intensity, error, q_array, dq_array, phi_array = _toQmodAndAzimuthal(i_of_q)
 
     # Filter by q_min and q_max
     allowed_q_index = np.logical_and((q_array > q_min), (q_array < q_max))
@@ -673,21 +671,21 @@ def bin_annular_into_q1d(i_of_q, theta_bin_params, q_min=0.001, q_max=0.4, metho
     # apply the selected binning method by either using or skipping the dq_array
     if dq_array is None:
         binned_i_of_azimuthal = do_1d_binning(
-            theta_array[allowed_q_index],
+            phi_array[allowed_q_index],
             None,
             intensity[allowed_q_index],
             error[allowed_q_index],
-            theta_bins,
+            phi_bins,
             None,
             1,
         )
     else:
         binned_i_of_azimuthal = do_1d_binning(
-            theta_array[allowed_q_index],
+            phi_array[allowed_q_index],
             dq_array[allowed_q_index],
             intensity[allowed_q_index],
             error[allowed_q_index],
-            theta_bins,
+            phi_bins,
             None,
             1,
         )

--- a/tests/unit/drtsans/test_i_of_q_annular_binning.py
+++ b/tests/unit/drtsans/test_i_of_q_annular_binning.py
@@ -21,9 +21,9 @@ def test_1d_annular_no_wt():
     -------
     None
     """
-    # Initialize range of theta angle and Q
-    theta_min = 0
-    theta_max = 360.0
+    # Initialize range of phi angle and Q
+    phi_min = 0
+    phi_max = 360.0
     num_bins = 10
 
     q_min = 0.003
@@ -44,8 +44,8 @@ def test_1d_annular_no_wt():
     )
 
     # Annular binning
-    theta_binning = BinningParams(theta_min, theta_max, num_bins)
-    binned_iq = bin_annular_into_q1d(test_i_q, theta_binning, q_min, q_max, BinningMethod.NOWEIGHT)
+    phi_binning = BinningParams(phi_min, phi_max, num_bins)
+    binned_iq = bin_annular_into_q1d(test_i_q, phi_binning, q_min, q_max, BinningMethod.NOWEIGHT)
 
     # Verify I(Q), sigma I(Q) and dQ
     assert binned_iq.intensity[1] == pytest.approx(63.66666667, abs=1e-8), "Binned intensity is wrong"
@@ -53,8 +53,8 @@ def test_1d_annular_no_wt():
     assert binned_iq.delta_mod_q[1] == pytest.approx(1.154e-02, abs=1e-5), (
         "Binned Q resolution {} is incorrect comparing to {}.".format(binned_iq.delta_mod_q[1], 0.01154)
     )
-    # this is actually theta
-    np.testing.assert_almost_equal(binned_iq.mod_q, np.linspace(start=18, stop=theta_max - 18, num=num_bins))
+    # this is actually phi
+    np.testing.assert_almost_equal(binned_iq.mod_q, np.linspace(start=18, stop=phi_max - 18, num=num_bins))
 
 
 def test_1d_annular_out_of_range_angles():
@@ -64,9 +64,9 @@ def test_1d_annular_out_of_range_angles():
     -------
     None
     """
-    # Initialize range of theta angle and Q
-    theta_min = -90
-    theta_max = 270.0
+    # Initialize range of phi angle and Q
+    phi_min = -90
+    phi_max = 270.0
     num_bins = 10
 
     q_min = 0.003
@@ -87,9 +87,9 @@ def test_1d_annular_out_of_range_angles():
     )
 
     # Annular binning
-    theta_binning = BinningParams(theta_min, theta_max, num_bins)
+    phi_binning = BinningParams(phi_min, phi_max, num_bins)
     with pytest.raises(ValueError):
-        bin_annular_into_q1d(test_i_q, theta_binning, q_min, q_max, BinningMethod.NOWEIGHT)
+        bin_annular_into_q1d(test_i_q, phi_binning, q_min, q_max, BinningMethod.NOWEIGHT)
 
 
 def test_1d_flat_data():
@@ -102,8 +102,8 @@ def test_1d_flat_data():
     )
 
     # perform the annular binning
-    theta_binning = BinningParams(0, 360, 18)  # 20 deg bins
-    binned_iq = bin_annular_into_q1d(data2d, theta_binning, q_min=9.0, q_max=10.0, method=BinningMethod.NOWEIGHT)
+    phi_binning = BinningParams(0, 360, 18)  # 20 deg bins
+    binned_iq = bin_annular_into_q1d(data2d, phi_binning, q_min=9.0, q_max=10.0, method=BinningMethod.NOWEIGHT)
 
     # verify the results
     assert binned_iq.intensity.size == 18


### PR DESCRIPTION
## Description of work:

Rename the azimuthal angle variables from `theta` to `phi`, since `theta` is typically used for the scattering angle and `phi` or `psi` is used for the angle around the beam center.

This PR is to make subsequent PR:s on annular binning easier to review.

No release note is needed since this PR just changes some variable names.

Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Story 364: [DRTSANS] Harmonizing the output style and content of 1D intensity profile obtained from annular binning](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=364)
- Links to related issues or pull requests:

## Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
