### PR TITLE
Add new class I1DAnnular to use for annular binning

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,10 +11,10 @@ Release Notes
   (date of release)
 
   **Of interest to the User**:
-  - MR #XYZ: one-liner description
+  - PR #XYZ: one-liner description
 
   **Of interest to the Developer:**
-  - MR #XYZ: one-liner description
+  - PR #XYZ: one-liner description
 ..
 
 ?.??.?
@@ -33,9 +33,10 @@ and configuration options.
 **Of interest to the User**:
 
 - PR #1008: Add support for annular binning with no wavelength binning.
+- PR #1005: Annular binning output is now annotated with phi rather than Q and plotted with a linear x axis
 - PR #999: Adds support for flexible time slicing.
 - PR #997: Fix bug causing symmetric auto wedge finding to fail. Add mirrored wedge to auto wedge fit function plot.
-- PR #998: remove the TOF offset that is done by the data aquisition system
+- PR #998: remove the TOF offset that is done by the data acquisition system
 - PR #996: Iq.dat files are now written even if they fail the assumption check
 - PR #994: Remove unused module `drtsans/tof/eqsans/reduce.py`
 - PR #993: Skip slices with too high transmission error when using time sliced sample transmission run

--- a/docs/user/binning.rst
+++ b/docs/user/binning.rst
@@ -4,6 +4,22 @@
 Binning
 =======
 
+Scalar Binning
+--------------
+
+Scalar or azimuthal binning produces a one dimensional intensity profile :math:`I(Q)` from
+:math:`I(x,y,\lambda)`.
+
+.. code-block:: json
+
+    {
+      "1DQbinType": "scalar",
+      "QbinType": "linear",
+      "numQBins": 200,
+      "Qmin": 0.003,
+      "Qmax": 0.005,
+    }
+
 
 Wedge Binning
 -------------
@@ -132,3 +148,19 @@ interpreted as background signal for the wedges.
 .. figure:: media/wedge_binning_7.png
    :alt: wedges for a real BIOSANS example
    :width: 900px
+
+Annular Binning
+---------------
+
+Annular binning produces a one dimensional intensity profile, :math:`I(\phi)`, which gives intensity
+as a function of the angle around the beam center, :math:`\phi`, over a limited range of scalar
+:math:`Q`. Annular binning uses linear spacing in :math:`\phi` with a default bin size of 1 degree.
+
+.. code-block:: json
+
+    {
+      "1DQbinType": "annular",
+      "AnnularAngleBin": 1.0,
+      "Qmin": 0.003,
+      "Qmax": 0.005,
+    }

--- a/src/drtsans/auto_wedge.py
+++ b/src/drtsans/auto_wedge.py
@@ -459,7 +459,7 @@ def _binInQAndAzimuthal(data, q_min, q_delta, q_max, azimuthal_delta):
     # debugging output file
     for qmin_ring, qmax_ring in zip(q_bins[:-1], q_bins[1:]):
         # bin into I(azimuthal)
-        I_annular = bin_annular_into_q1d(data, azimuthal_binning, qmin_ring, qmax_ring, BinningMethod.NOWEIGHT)
+        i1d_annular = bin_annular_into_q1d(data, azimuthal_binning, qmin_ring, qmax_ring, BinningMethod.NOWEIGHT)
 
         # Create a copy of the arrays with the 360->540deg region repeated
         # ignore - delta_mod_q wavelength
@@ -468,21 +468,21 @@ def _binInQAndAzimuthal(data, q_min, q_delta, q_max, azimuthal_delta):
             x_max=540.0 + azimuthal_delta,
             bins=1 + int(540.0 / azimuthal_delta),
         ).centers
-        num_orig_bins = I_annular.phi.size
+        num_orig_bins = i1d_annular.phi.size
         num_repeated_bins = phi_new.size - num_orig_bins
 
         intensity_new = np.zeros(phi_new.size)
-        intensity_new[:num_orig_bins] = I_annular.intensity
-        intensity_new[-1 * num_repeated_bins :] = I_annular.intensity[:num_repeated_bins]
+        intensity_new[:num_orig_bins] = i1d_annular.intensity
+        intensity_new[-1 * num_repeated_bins :] = i1d_annular.intensity[:num_repeated_bins]
 
         error_new = np.zeros(phi_new.size)
-        error_new[:num_orig_bins] = I_annular.error
-        error_new[-1 * num_repeated_bins :] = I_annular.error[:num_repeated_bins]
+        error_new[:num_orig_bins] = i1d_annular.error
+        error_new[-1 * num_repeated_bins :] = i1d_annular.error[:num_repeated_bins]
 
-        I_annular = I1DAnnular(intensity=intensity_new, error=error_new, phi=phi_new)
+        i1d_annular = I1DAnnular(intensity=intensity_new, error=error_new, phi=phi_new)
 
         # append to the list of spectra
-        data_of_q_rings.append(I_annular)
+        data_of_q_rings.append(i1d_annular)
 
     return q_bins, data_of_q_rings
 

--- a/src/drtsans/auto_wedge.py
+++ b/src/drtsans/auto_wedge.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os
 from typing import List, Tuple
-from drtsans.dataobjects import IQmod
+from drtsans.dataobjects import I1DAnnular
 from drtsans.determine_bins import determine_1d_linear_bins
 from drtsans.iq import BinningMethod, BinningParams, bin_annular_into_q1d
 
@@ -150,7 +150,7 @@ def _plot_fit_results(rings, peak_fit_dict, output_dir, auto_symmetric_wedges):
                 # parameter value is recorded as tuple as value and error
                 _set_function_param_value(fit_function_set, param_name, peak_fitted_dict[param_name][0])
         # calculate
-        model_y = _calculate_function(fit_functions, ring.mod_q)
+        model_y = _calculate_function(fit_functions, ring.phi)
         return model_y
 
     for index, ring in enumerate(rings):
@@ -163,7 +163,7 @@ def _plot_fit_results(rings, peak_fit_dict, output_dir, auto_symmetric_wedges):
         fit_function_str = peak_fit_dict[index]["fit_function"]
         fit_function_set = _create_fit_function(fit_function_str)
         # calculate estimated peaks
-        estimated_y = _calculate_function(fit_function_set, ring.mod_q)
+        estimated_y = _calculate_function(fit_function_set, ring.phi)
 
         if auto_symmetric_wedges:
             # separate fitted peak ("f1" params) from mirrored peak (fake "f2" params) to plot them separately
@@ -185,12 +185,12 @@ def _plot_fit_results(rings, peak_fit_dict, output_dir, auto_symmetric_wedges):
 
         # plot
         plt.cla()
-        plt.plot(ring.mod_q, ring.intensity, label="observed", color="black")
-        plt.plot(ring.mod_q, estimated_y, label="estimated", color="blue")
-        plt.plot(ring.mod_q, model_y, label="fitted", color="red")
+        plt.plot(ring.phi, ring.intensity, label="observed", color="black")
+        plt.plot(ring.phi, estimated_y, label="estimated", color="blue")
+        plt.plot(ring.phi, model_y, label="fitted", color="red")
         if auto_symmetric_wedges:
             mirrored_model_y = _set_function_params_and_calculate(fit_function_set, peak_mirrored_dict)
-            plt.plot(ring.mod_q, mirrored_model_y, label="mirrored", color="red", linestyle="dashed")
+            plt.plot(ring.phi, mirrored_model_y, label="mirrored", color="red", linestyle="dashed")
         plt.legend(loc="upper left")
         plt.savefig(os.path.join(output_dir, f"ring_{index:01}.png"))
 
@@ -235,7 +235,7 @@ def _export_to_h5(iq2d, rings, azimuthal_delta, peak_fit_dict, output_dir):
 
     # write full range
     group = ring_group.create_group("full range")
-    group.create_dataset("q", data=full_range_annular.mod_q)
+    group.create_dataset("phi", data=full_range_annular.phi)
     group.create_dataset("intensity", data=full_range_annular.intensity)
 
     # write out for each ring
@@ -244,7 +244,7 @@ def _export_to_h5(iq2d, rings, azimuthal_delta, peak_fit_dict, output_dir):
     for index, ring in enumerate(rings):
         # add data to hdf file
         group = ring_group.create_group(f"ring {index}")
-        group.create_dataset("q", data=ring.mod_q)
+        group.create_dataset("phi", data=ring.phi)
         group.create_dataset("intensity", data=ring.intensity)
 
         # add fitting related information to hdf file
@@ -459,30 +459,30 @@ def _binInQAndAzimuthal(data, q_min, q_delta, q_max, azimuthal_delta):
     # debugging output file
     for qmin_ring, qmax_ring in zip(q_bins[:-1], q_bins[1:]):
         # bin into I(azimuthal)
-        I_azimuthal = bin_annular_into_q1d(data, azimuthal_binning, qmin_ring, qmax_ring, BinningMethod.NOWEIGHT)
+        I_annular = bin_annular_into_q1d(data, azimuthal_binning, qmin_ring, qmax_ring, BinningMethod.NOWEIGHT)
 
         # Create a copy of the arrays with the 360->540deg region repeated
         # ignore - delta_mod_q wavelength
-        mod_q_new = determine_1d_linear_bins(
+        phi_new = determine_1d_linear_bins(
             x_min=0.0,
             x_max=540.0 + azimuthal_delta,
             bins=1 + int(540.0 / azimuthal_delta),
         ).centers
-        num_orig_bins = I_azimuthal.mod_q.size
-        num_repeated_bins = mod_q_new.size - num_orig_bins
+        num_orig_bins = I_annular.phi.size
+        num_repeated_bins = phi_new.size - num_orig_bins
 
-        intensity_new = np.zeros(mod_q_new.size)
-        intensity_new[:num_orig_bins] = I_azimuthal.intensity
-        intensity_new[-1 * num_repeated_bins :] = I_azimuthal.intensity[:num_repeated_bins]
+        intensity_new = np.zeros(phi_new.size)
+        intensity_new[:num_orig_bins] = I_annular.intensity
+        intensity_new[-1 * num_repeated_bins :] = I_annular.intensity[:num_repeated_bins]
 
-        error_new = np.zeros(mod_q_new.size)
-        error_new[:num_orig_bins] = I_azimuthal.error
-        error_new[-1 * num_repeated_bins :] = I_azimuthal.error[:num_repeated_bins]
+        error_new = np.zeros(phi_new.size)
+        error_new[:num_orig_bins] = I_annular.error
+        error_new[-1 * num_repeated_bins :] = I_annular.error[:num_repeated_bins]
 
-        I_azimuthal = IQmod(intensity=intensity_new, error=error_new, mod_q=mod_q_new)
+        I_annular = I1DAnnular(intensity=intensity_new, error=error_new, phi=phi_new)
 
         # append to the list of spectra
-        data_of_q_rings.append(I_azimuthal)
+        data_of_q_rings.append(I_annular)
 
     return q_bins, data_of_q_rings
 
@@ -640,7 +640,7 @@ def _fitSpectrum(
     # guess where one peak might be, start with a window of WINDOW_SIZE each side around 110
     intensity_peak, azimuthal_first, sigma = _estimatePeakParameters(
         spectrum.intensity[mask],
-        spectrum.mod_q[mask],
+        spectrum.phi[mask],
         azimuthal_start=azimuthal_start,
         window_half_width=peak_search_window_size,
     )
@@ -651,7 +651,7 @@ def _fitSpectrum(
         azimuthal_start = azimuthal_first + 180.0
         intensity_peak, azimuthal_second, sigma = _estimatePeakParameters(
             spectrum.intensity[mask],
-            spectrum.mod_q[mask],
+            spectrum.phi[mask],
             azimuthal_start=azimuthal_start,
             window_half_width=peak_search_window_size,
         )
@@ -670,8 +670,8 @@ def _fitSpectrum(
                 Function=fit_function,
                 InputWorkspace=q_azimuthal_workspace,
                 Output=fit_workspace_prefix,
-                StartX=spectrum.mod_q.min() + auto_wedge_phi_min,
-                EndX=spectrum.mod_q.min() + auto_wedge_phi_max,
+                StartX=spectrum.phi.min() + auto_wedge_phi_min,
+                EndX=spectrum.phi.min() + auto_wedge_phi_max,
                 OutputParametersOnly=True,
                 IgnoreInvalidData=True,
             )
@@ -680,8 +680,8 @@ def _fitSpectrum(
                 Function=fit_function,
                 InputWorkspace=q_azimuthal_workspace,
                 Output=fit_workspace_prefix,
-                StartX=spectrum.mod_q.min() + 90.0,
-                EndX=spectrum.mod_q.min() + 90.0 + 360.0,
+                StartX=spectrum.phi.min() + 90.0,
+                EndX=spectrum.phi.min() + 90.0 + 360.0,
                 OutputParametersOnly=True,
                 IgnoreInvalidData=True,
             )

--- a/src/drtsans/dataobjects.py
+++ b/src/drtsans/dataobjects.py
@@ -599,18 +599,6 @@ class I1DAnnular(namedtuple("I1DAnnular", "intensity error phi wavelength"), I1D
     def id(self):
         return DataType.I_ANNULAR
 
-    def be_finite(self):
-        #  Remove NaN
-        finite_locations = np.isfinite(self.intensity)
-        finite_binned_i_wl = I1DAnnular(
-            intensity=self.intensity[finite_locations],
-            error=self.error[finite_locations],
-            phi=self.phi[finite_locations],
-            wavelength=self.wavelength[finite_locations],
-        )
-
-        return finite_binned_i_wl
-
     def to_workspace(self, name=None):
         # create a name if one isn't provided
         if name is None:

--- a/src/drtsans/dataobjects.py
+++ b/src/drtsans/dataobjects.py
@@ -600,6 +600,17 @@ class I1DAnnular(namedtuple("I1DAnnular", "intensity error phi wavelength"), I1D
     def id(self):
         return DataType.I_ANNULAR
 
+    def be_finite(self):
+        #  Remove NaN
+        finite_locations = np.isfinite(self.intensity)
+        finite_binned_i_wl = I1DAnnular(
+            intensity=self.intensity[finite_locations],
+            error=self.error[finite_locations],
+            phi=self.phi[finite_locations],
+            wavelength=self.wavelength[finite_locations],
+        )
+        return finite_binned_i_wl
+
     def to_workspace(self, name=None):
         # create a name if one isn't provided
         if name is None:

--- a/src/drtsans/dataobjects.py
+++ b/src/drtsans/dataobjects.py
@@ -183,6 +183,16 @@ def verify_same_q_bins(iq0, iq1, raise_exception_if_diffrent=False, tolerance=No
         else:
             q0vec = np.array([iq0.qx, iq0.qy, iq0.wavelength])
             q1vec = np.array([iq1.qx, iq1.qy, iq0.wavelength])
+    elif isinstance(iq0, I1DAnnular):
+        # Q1D
+        if iq0.wavelength is None or iq1.wavelength is None:
+            # no wavelength
+            q0vec = iq0.phi
+            q1vec = iq1.phi
+        else:
+            # also comparing the wavelength bins if they do exist
+            q0vec = np.array([iq0.phi, iq0.wavelength])
+            q1vec = np.array([iq1.phi, iq1.wavelength])
     else:
         raise RuntimeError(f"I(Q) of type {type(iq0)} is not supported by verify same binning")
 
@@ -390,6 +400,14 @@ class IQmod(namedtuple("IQmod", "intensity error mod_q delta_mod_q wavelength"),
         r"""Divide intensities and their uncertainties by a number"""
         return self.__mul__(1.0 / divisor)
 
+    @property
+    def x(self):
+        return self.mod_q
+
+    @property
+    def delta_x(self):
+        return self.delta_mod_q
+
     def extract(self, selection):
         r"""
         Extract a subset of data points onto a new ~drtsans.dataobjects.IQmod object.
@@ -518,6 +536,14 @@ class I1DAnnular(namedtuple("I1DAnnular", "intensity error phi wavelength"), I1D
     def __truediv__(self, divisor):
         r"""Divide intensities and their uncertainties by a number"""
         return self.__mul__(1.0 / divisor)
+
+    @property
+    def x(self):
+        return self.phi
+
+    @property
+    def delta_x(self):
+        return None
 
     def extract(self, selection):
         r"""

--- a/src/drtsans/iq.py
+++ b/src/drtsans/iq.py
@@ -607,9 +607,9 @@ def bin_annular_into_q1d(
 ):
     """Annular 1D binning
 
-    Calculates: I(azimuthal), sigma I and dazmuthal by assigning pixels to proper azimuthal angle bins
-    Given I(Qx, Qy) and will convert to :py:obj:`~drtsans.IQmod` in the code. The independent axis is
-    actually the azimuthal angle around the ring.
+    Calculates: I(azimuthal) and sigma I by assigning pixels to proper azimuthal angle bins
+    Input is I(Qx, Qy) and output is :py:obj:`~drtsans.dataobjects.I1DAnnular`.
+    The independent axis is the azimuthal angle around the beam center.
 
     Parameters
     ----------

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -1679,11 +1679,11 @@ def reduce_single_configuration(
             skip_nan,
         )
 
-        IofQ_output = namedtuple(
-            "IofQ_output",
+        I_output = namedtuple(
+            "I_output",
             ["I2D_main", "I2D_midrange", "I2D_wing", "I1D_main", "I1D_midrange", "I1D_wing", "I1D_combined"],
         )
-        current_output = IofQ_output(
+        current_output = I_output(
             I2D_main=iq2d_main_out,
             I2D_midrange=iq2d_midrange_out,
             I2D_wing=iq2d_wing_out,

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -1084,7 +1084,7 @@ def plot_reduction_output(
         #       not work with the standard import, therefore we need to use
         #       full path import here to make unit test work.
         plot_IQazimuthal = drtsans.plots.api.plot_IQazimuthal
-        plot_IQmod = drtsans.plots.api.plot_IQmod
+        plot_i1d = drtsans.plots.api.plot_i1d
         allow_overwrite = drtsans.path.allow_overwrite
 
         # main detector
@@ -1139,18 +1139,18 @@ def plot_reduction_output(
                 add_suffix = f"_wedge_{j}"
             filename = os.path.join(output_dir, "1D", f"{outputFilename}{output_suffix}_1D{add_suffix}.png")
             if has_midrange_detector:
-                plot_IQmod(
+                plot_i1d(
                     [out.I1D_main[j], out.I1D_wing[j], out.I1D_midrange[j], out.I1D_combined[j]],
                     filename,
-                    loglog=loglog,
+                    log_scale=loglog,
                     backend="mpl",
                     errorbar_kwargs={"label": "main,wing,midrange,both"},
                 )
             else:
-                plot_IQmod(
+                plot_i1d(
                     [out.I1D_main[j], out.I1D_wing[j], out.I1D_combined[j]],
                     filename,
-                    loglog=loglog,
+                    log_scale=loglog,
                     backend="mpl",
                     errorbar_kwargs={"label": "main,wing,both"},
                 )

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -3,7 +3,7 @@
 # local imports
 import drtsans
 from drtsans import getWedgeSelection, subtract_background, NoDataProcessedError
-from drtsans.dataobjects import save_iqmod, IQazimuthal
+from drtsans.dataobjects import save_i1d, IQazimuthal
 from drtsans.instruments import extract_run_number
 from drtsans.iq import bin_all
 from drtsans.load import move_instrument
@@ -1668,7 +1668,7 @@ def reduce_single_configuration(
             i1d_profiles_out = [i1d_main_out, i1d_midrange_out, i1d_wing_out]
         iq1d_combined_out = stitch_binned_profiles(iq1d_profiles_in, i1d_profiles_out, reduction_config)
 
-        save_iqmod_all(
+        save_i1d_all(
             i1d_main_out,
             i1d_midrange_out,
             i1d_wing_out,
@@ -1761,7 +1761,7 @@ def reduce_single_configuration(
     return output
 
 
-def save_iqmod_all(
+def save_i1d_all(
     iq1d_main, iq1d_midrange, iq1d_wing, iq1d_combined, output_filename, output_dir, output_suffix, skip_nan
 ):
     """Save to file the intensity profiles for the individual detectors, as well as the combined (stitched) profile
@@ -1794,14 +1794,14 @@ def save_iqmod_all(
             "1D",
             f"{output_filename}{output_suffix}_1D_main{add_suffix}.txt",
         )
-        save_iqmod(iq1d_main[j], main_1D_filename, skip_nan=skip_nan)
+        save_i1d(iq1d_main[j], main_1D_filename, skip_nan=skip_nan)
 
         wing_1D_filename = os.path.join(
             output_dir,
             "1D",
             f"{output_filename}{output_suffix}_1D_wing{add_suffix}.txt",
         )
-        save_iqmod(iq1d_wing[j], wing_1D_filename, skip_nan=skip_nan)
+        save_i1d(iq1d_wing[j], wing_1D_filename, skip_nan=skip_nan)
 
         if iq1d_midrange:
             midrange_1D_filename = os.path.join(
@@ -1809,14 +1809,14 @@ def save_iqmod_all(
                 "1D",
                 f"{output_filename}{output_suffix}_1D_midrange{add_suffix}.txt",
             )
-            save_iqmod(iq1d_midrange[j], midrange_1D_filename, skip_nan=skip_nan)
+            save_i1d(iq1d_midrange[j], midrange_1D_filename, skip_nan=skip_nan)
 
         combined_1D_filename = os.path.join(
             output_dir,
             "1D",
             f"{output_filename}{output_suffix}_1D_combined{add_suffix}.txt",
         )
-        save_iqmod(iq1d_combined[j], combined_1D_filename, skip_nan=skip_nan)
+        save_i1d(iq1d_combined[j], combined_1D_filename, skip_nan=skip_nan)
 
 
 def get_sample_detectordata(

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -1576,7 +1576,7 @@ def reduce_single_configuration(
         reduction_config["wedges"] = wedges
         reduction_config["symmetric_wedges"] = symmetric_wedges
 
-        iq2d_main_out, iq1d_main_out = bin_all(
+        iq2d_main_out, i1d_main_out = bin_all(
             iq2d_main_in,
             iq1d_main_in,
             nxbins_main,
@@ -1599,7 +1599,7 @@ def reduce_single_configuration(
         )
         iq1d_wing_in = biosans.convert_to_q(processed_data_wing, mode="scalar")
         iq2d_wing_in = biosans.convert_to_q(processed_data_wing, mode="azimuthal")
-        iq2d_wing_out, iq1d_wing_out = bin_all(
+        iq2d_wing_out, i1d_wing_out = bin_all(
             iq2d_wing_in,
             iq1d_wing_in,
             nxbins_wing,
@@ -1623,7 +1623,7 @@ def reduce_single_configuration(
         if reduction_config["has_midrange_detector"]:
             iq1d_midrange_in = biosans.convert_to_q(processed_data_midrange, mode="scalar")
             iq2d_midrange_in = biosans.convert_to_q(processed_data_midrange, mode="azimuthal")
-            iq2d_midrange_out, iq1d_midrange_out = bin_all(
+            iq2d_midrange_out, i1d_midrange_out = bin_all(
                 iq2d_midrange_in,
                 iq1d_midrange_in,
                 nxbins_midrange,
@@ -1645,7 +1645,7 @@ def reduce_single_configuration(
                 error_weighted=weighted_errors,
             )
         else:
-            iq2d_midrange_out, iq1d_midrange_out = (IQazimuthal(intensity=[], error=[], qx=[], qy=[]), [])
+            iq2d_midrange_out, i1d_midrange_out = (IQazimuthal(intensity=[], error=[], qx=[], qy=[]), [])
 
         # create output directories
         create_output_dir(output_dir)
@@ -1662,16 +1662,16 @@ def reduce_single_configuration(
         # intensity profiles in the order of stitching (lower to higher Q)
         if not reduction_config["has_midrange_detector"] or reduction_config["overlapStitchIgnoreMidrange"]:
             iq1d_profiles_in = [iq1d_main_in, iq1d_wing_in]
-            iq1d_profiles_out = [iq1d_main_out, iq1d_wing_out]
+            i1d_profiles_out = [i1d_main_out, i1d_wing_out]
         else:
             iq1d_profiles_in = [iq1d_main_in, iq1d_midrange_in, iq1d_wing_in]
-            iq1d_profiles_out = [iq1d_main_out, iq1d_midrange_out, iq1d_wing_out]
-        iq1d_combined_out = stitch_binned_profiles(iq1d_profiles_in, iq1d_profiles_out, reduction_config)
+            i1d_profiles_out = [i1d_main_out, i1d_midrange_out, i1d_wing_out]
+        iq1d_combined_out = stitch_binned_profiles(iq1d_profiles_in, i1d_profiles_out, reduction_config)
 
         save_iqmod_all(
-            iq1d_main_out,
-            iq1d_midrange_out,
-            iq1d_wing_out,
+            i1d_main_out,
+            i1d_midrange_out,
+            i1d_wing_out,
             iq1d_combined_out,
             outputFilename,
             output_dir,
@@ -1687,17 +1687,17 @@ def reduce_single_configuration(
             I2D_main=iq2d_main_out,
             I2D_midrange=iq2d_midrange_out,
             I2D_wing=iq2d_wing_out,
-            I1D_main=iq1d_main_out,
-            I1D_midrange=iq1d_midrange_out,
-            I1D_wing=iq1d_wing_out,
+            I1D_main=i1d_main_out,
+            I1D_midrange=i1d_midrange_out,
+            I1D_wing=i1d_wing_out,
             I1D_combined=iq1d_combined_out,
         )
         output.append(current_output)
 
         detectordata[sample_name] = get_sample_detectordata(
-            iq1d_main_out,
-            iq1d_midrange_out,
-            iq1d_wing_out,
+            i1d_main_out,
+            i1d_midrange_out,
+            i1d_wing_out,
             iq1d_combined_out,
             iq2d_main_out,
             iq2d_midrange_out,

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -1826,13 +1826,13 @@ def get_sample_detectordata(
 
     Parameters
     ----------
-    iq1d_main: ~drtsans.dataobjects.IQmod
+    iq1d_main: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
         Intensity profile for the main detector
-    iq1d_midrange: ~drtsans.dataobjects.IQmod
+    iq1d_midrange: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
         Intensity profile for the midrange detector
-    iq1d_wing: ~drtsans.dataobjects.IQmod
+    iq1d_wing: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
         Intensity profile for the wing detector
-    iq1d_combined: ~drtsans.dataobjects.IQmod
+    iq1d_combined: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
         Combined (stitched) intensity profile from different detectors
     iq2d_main: ~drtsans.dataobjects.IQazimuthal
         I(Qx, Qy) for the main detector
@@ -1846,15 +1846,15 @@ def get_sample_detectordata(
     detector_data = {}
     # TODO: fix this bug - only one combined profile is saved in the reduction log, but for wedges there are two
     if iq1d_combined[-1].intensity.size > 0:
-        detector_data["combined"] = {"iq": [iq1d_combined[-1]]}
+        detector_data["combined"] = {"i1d": [iq1d_combined[-1]]}
 
     # one 1D I(Q) per detector for scalar and annular binning and two 1D I(Q) per detector for wedge binning
     for index, (_iq1d_main, _iq1d_wing) in enumerate(zip(iq1d_main, iq1d_wing)):
-        detector_data[f"main_{index}"] = {"iq": [_iq1d_main]}
-        detector_data[f"wing_{index}"] = {"iq": [_iq1d_wing]}
+        detector_data[f"main_{index}"] = {"i1d": [_iq1d_main]}
+        detector_data[f"wing_{index}"] = {"i1d": [_iq1d_wing]}
     if has_midrange:
         for index, (_iq1d_midrange) in enumerate(iq1d_midrange):
-            detector_data[f"midrange_{index}"] = {"iq": [_iq1d_midrange]}
+            detector_data[f"midrange_{index}"] = {"i1d": [_iq1d_midrange]}
 
     # one 2D I(Q) per detector, assign to index 0
     index = 0

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 # local imports
 from drtsans import getWedgeSelection, subtract_background, NoDataProcessedError
 from drtsans.beam_finder import center_detector, fbc_options_json, find_beam_center
-from drtsans.dataobjects import save_iqmod
+from drtsans.dataobjects import save_i1d
 from drtsans.instruments import extract_run_number, instrument_filesystem_name
 from drtsans.iq import bin_all
 from drtsans.load import move_instrument, resolve_slicing
@@ -1348,7 +1348,7 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
                 add_suffix = f"_wedge_{j}"
             ascii_1D_filename = os.path.join(output_dir, "1D", f"{outputFilename}{output_suffix}_1D{add_suffix}")
 
-            save_iqmod(i1d_main_out[j], f"{ascii_1D_filename}.txt", skip_nan=skip_nan)
+            save_i1d(i1d_main_out[j], f"{ascii_1D_filename}.txt", skip_nan=skip_nan)
 
         IofQ_output = namedtuple("IofQ_output", ["I2D_main", "I1D_main"])
         current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -49,7 +49,7 @@ from drtsans.mono.normalization import (
 from drtsans.path import allow_overwrite
 from drtsans.mono.transmission import apply_transmission_correction, calculate_transmission
 from drtsans.path import abspath, abspaths, registered_workspace
-from drtsans.plots import plot_detector, plot_IQazimuthal, plot_IQmod
+from drtsans.plots import plot_detector, plot_IQazimuthal, plot_i1d
 from drtsans.reductionlog import savereductionlog
 from drtsans.samplelogs import SampleLogs
 from drtsans.sensitivity import apply_sensitivity_correction, load_sensitivity_workspace
@@ -1460,10 +1460,10 @@ def plot_reduction_output(
             if len(out.I1D_main) > 1:
                 add_suffix = f"_wedge_{j}"
             filename = os.path.join(output_dir, "1D", f"{outputFilename}{output_suffix}_1D{add_suffix}.png")
-            plot_IQmod(
+            plot_i1d(
                 [out.I1D_main[j]],
                 filename,
-                loglog=loglog,
+                log_scale=loglog,
                 backend="mpl",
                 errorbar_kwargs={"label": "main"},
             )

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -1350,8 +1350,8 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
 
             save_i1d(i1d_main_out[j], f"{ascii_1D_filename}.txt", skip_nan=skip_nan)
 
-        IofQ_output = namedtuple("IofQ_output", ["I2D_main", "I1D_main"])
-        current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
+        I_output = namedtuple("I_output", ["I2D_main", "I1D_main"])
+        current_output = I_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
         output.append(current_output)
 
         detectordata[name] = {"main": {"iq": i1d_main_out, "iqxqy": iq2d_main_out}}

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -1354,7 +1354,7 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
         current_output = I_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
         output.append(current_output)
 
-        detectordata[name] = {"main": {"iq": i1d_main_out, "iqxqy": iq2d_main_out}}
+        detectordata[name] = {"main": {"i1d": i1d_main_out, "iqxqy": iq2d_main_out}}
 
     try:
         processed_data_main

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -1319,7 +1319,7 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
         reduction_config["wedges"] = wedges
         reduction_config["symmetric_wedges"] = symmetric_wedges
 
-        iq2d_main_out, iq1d_main_out = bin_all(
+        iq2d_main_out, i1d_main_out = bin_all(
             iq2d_main_in,
             iq1d_main_in,
             nxbins_main,
@@ -1342,19 +1342,19 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
         save_ascii_binned_2D(f"{filename}.dat", "I(Qx,Qy)", iq2d_main_out)
         save_cansas_nx(iq2d_main_out.to_workspace(), f"{filename}.h5")
 
-        for j in range(len(iq1d_main_out)):
+        for j in range(len(i1d_main_out)):
             add_suffix = ""
-            if len(iq1d_main_out) > 1:
+            if len(i1d_main_out) > 1:
                 add_suffix = f"_wedge_{j}"
             ascii_1D_filename = os.path.join(output_dir, "1D", f"{outputFilename}{output_suffix}_1D{add_suffix}")
 
-            save_iqmod(iq1d_main_out[j], f"{ascii_1D_filename}.txt", skip_nan=skip_nan)
+            save_iqmod(i1d_main_out[j], f"{ascii_1D_filename}.txt", skip_nan=skip_nan)
 
         IofQ_output = namedtuple("IofQ_output", ["I2D_main", "I1D_main"])
-        current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=iq1d_main_out)
+        current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
         output.append(current_output)
 
-        detectordata[name] = {"main": {"iq": iq1d_main_out, "iqxqy": iq2d_main_out}}
+        detectordata[name] = {"main": {"iq": i1d_main_out, "iqxqy": iq2d_main_out}}
 
     try:
         processed_data_main

--- a/src/drtsans/mono/momentum_transfer.py
+++ b/src/drtsans/mono/momentum_transfer.py
@@ -74,8 +74,8 @@ def convert_to_q(ws, mode, resolution_function=mono_resolution, **kwargs):
     series of arrays: intensity, error, q (or q components),
     delta q (or delta q components), and wavelength
 
-    Using the scattering angle as :math:`2\theta` and azimuthan angle as
-    :math:`\phi`,the calculaion of momentum transfer is:
+    Using the scattering angle as :math:`2\theta` and azimuthal angle as
+    :math:`\phi`,the calculation of momentum transfer is:
 
     - 'scalar' mode:
 

--- a/src/drtsans/plots/api.py
+++ b/src/drtsans/plots/api.py
@@ -216,7 +216,7 @@ def plot_I1DAnnular(workspaces, filename, logy=True, backend: str = "d3", errorb
         for key in errorbar_kwargs:
             value = [v.strip() for v in errorbar_kwargs[key].split(",")]
             plt.setp(eb, key, value[min(n, len(value) - 1)])
-    ax.set_xlabel("Azimuthal angle (degrees)")
+    ax.set_xlabel("$\\phi$ (degrees)")
     ax.set_ylabel("Intensity")
     if logy:
         # only setting log for y scale, since log scale for the x axis (annular angle) doesn't make sense

--- a/src/drtsans/plots/api.py
+++ b/src/drtsans/plots/api.py
@@ -128,10 +128,8 @@ def plot_IQmod(workspaces, filename, loglog=True, backend: str = "d3", errorbar_
 
     Parameters
     ----------
-    workspaces: list, tuple
-        A collection of :py:obj:`~drtsans.dataobjects.IQmod` workspaces to
-        plot. If only one is desired, it must still be supplied in a
-        :py:obj:`list` or :py:obj:`tuple`.
+    workspaces: list, tuple, :py:obj:`~drtsans.dataobjects.IQmod`
+        A collection of :py:obj:`~drtsans.dataobjects.IQmod` workspaces to plot.
     filename: str
         The name of the file to save to. For the :py:obj:`~Backend.MATPLOTLIB`
         backend, the type of file is determined from the file extension
@@ -147,6 +145,9 @@ def plot_IQmod(workspaces, filename, loglog=True, backend: str = "d3", errorbar_
         Additional key word arguments for :py:obj:`matplotlib.axes.Axes`
 
     """
+    if not isinstance(workspaces, (list, tuple)):
+        workspaces = [workspaces]
+
     if errorbar_kwargs is None:
         errorbar_kwargs = {}
     backend = Backend.getMode(backend)
@@ -182,10 +183,8 @@ def plot_I1DAnnular(workspaces, filename, logy=True, backend: str = "d3", errorb
 
     Parameters
     ----------
-    workspaces: list, tuple
-        A collection of :py:obj:`~drtsans.dataobjects.I1DAnnular` workspaces to
-        plot. If only one is desired, it must still be supplied in a
-        :py:obj:`list` or :py:obj:`tuple`.
+    workspaces: list, tuple, :py:obj:`~drtsans.dataobjects.I1DAnnular`
+        A collection of :py:obj:`~drtsans.dataobjects.I1DAnnular` workspaces to plot.
     filename: str
         The name of the file to save to. For the :py:obj:`~Backend.MATPLOTLIB`
         backend, the type of file is determined from the file extension
@@ -201,6 +200,9 @@ def plot_I1DAnnular(workspaces, filename, logy=True, backend: str = "d3", errorb
         Additional key word arguments for :py:obj:`matplotlib.axes.Axes`
 
     """
+    if not isinstance(workspaces, (list, tuple)):
+        workspaces = [workspaces]
+
     if errorbar_kwargs is None:
         errorbar_kwargs = {}
 
@@ -237,10 +239,9 @@ def plot_i1d(workspaces, filename, log_scale=True, backend: str = "d3", errorbar
 
     Parameters
     ----------
-    workspaces: list, tuple
+    workspaces: list, tuple, :py:obj:`~drtsans.dataobjects.IQmod`, :py:obj:`~drtsans.dataobjects.I1DAnnular`
         A collection of :py:obj:`~drtsans.dataobjects.IQmod` or
-        :py:obj:`~drtsans.dataobjects.I1DAnnular` workspaces to plot. If only one is desired, it
-        must still be supplied in a :py:obj:`list` or :py:obj:`tuple`.
+        :py:obj:`~drtsans.dataobjects.I1DAnnular` workspaces to plot.
     filename: str
         The name of the file to save to. For the :py:obj:`~Backend.MATPLOTLIB`
         backend, the type of file is determined from the file extension
@@ -256,6 +257,9 @@ def plot_i1d(workspaces, filename, log_scale=True, backend: str = "d3", errorbar
         Additional key word arguments for :py:obj:`matplotlib.axes.Axes`
 
     """
+    if not isinstance(workspaces, (list, tuple)):
+        workspaces = [workspaces]
+
     datatypes = []
     for workspace in workspaces:
         datatype = getDataType(workspace)

--- a/src/drtsans/plots/api.py
+++ b/src/drtsans/plots/api.py
@@ -268,7 +268,7 @@ def plot_i1d(workspaces, filename, log_scale=True, backend: str = "d3", errorbar
 
     if datatypes[0] == DataType.IQ_MOD:
         plot_IQmod(workspaces, filename, log_scale, backend, errorbar_kwargs, **kwargs)
-    else:
+    else:  # can only be DataType.I_ANNULAR
         plot_I1DAnnular(workspaces, filename, log_scale, backend, errorbar_kwargs, **kwargs)
 
 

--- a/src/drtsans/reductionlog.py
+++ b/src/drtsans/reductionlog.py
@@ -226,7 +226,7 @@ def _savesamplelogs(nxentry, dict_sample_logs, name_of_entry):
             _new_entry.attrs["units"] = _units
 
 
-def _create_groupe(entry=None, name="Default", data=[], units=""):
+def _create_group(entry=None, name="Default", data=[], units=""):
     if data is not None:
         _entry_group = entry.create_dataset(name=name, data=data)
         _entry_group.attrs["units"] = units
@@ -240,7 +240,7 @@ def _save_logslicedata(logslicedata={}, index=0, topEntry=None):
     entry = topEntry.create_group(nameGroup)
     entry.attrs["NX_class"] = "NXdata"
 
-    _create_groupe(
+    _create_group(
         entry=entry,
         name="data",
         data=logslicedata[str(index)]["data"],
@@ -253,26 +253,26 @@ def _save_iqxqy_to_log(iqxqy=None, topEntry=None):
     entry.attrs["NX_class"] = "NXdata"
 
     # intensity
-    _create_groupe(entry=entry, name="I", data=iqxqy.intensity, units="1/A")
+    _create_group(entry=entry, name="I", data=iqxqy.intensity, units="1/A")
 
     # errors
-    _create_groupe(entry=entry, name="Idev", data=iqxqy.error, units="1/cm")
+    _create_group(entry=entry, name="Idev", data=iqxqy.error, units="1/cm")
 
     # qx
     if iqxqy.qx is not None:
-        _create_groupe(entry=entry, name="Qx", data=iqxqy.qx, units="1/A")
+        _create_group(entry=entry, name="Qx", data=iqxqy.qx, units="1/A")
 
-        _create_groupe(entry=entry, name="Qxdev", data=iqxqy.delta_qx, units="1/A")
+        _create_group(entry=entry, name="Qxdev", data=iqxqy.delta_qx, units="1/A")
 
     # qy
     if iqxqy.qy is not None:
-        _create_groupe(entry=entry, name="Qy", data=iqxqy.qy, units="1/A")
+        _create_group(entry=entry, name="Qy", data=iqxqy.qy, units="1/A")
 
-        _create_groupe(entry=entry, name="Qydev", data=iqxqy.delta_qy, units="1/A")
+        _create_group(entry=entry, name="Qydev", data=iqxqy.delta_qy, units="1/A")
     # wavelength
     if iqxqy.wavelength is not None:
         wavelength = "{}".format(iqxqy.wavelength)
-        _create_groupe(entry=entry, name="Wavelength", data=wavelength, units="A")
+        _create_group(entry=entry, name="Wavelength", data=wavelength, units="A")
 
 
 def __save_individual_i1d_to_log(i1d=None, topEntry=None, entryNameExt=""):
@@ -318,22 +318,22 @@ def __save_individual_iq_to_log(iq=None, topEntry=None, entryNameExt=""):
     entry.attrs["axes"] = "Q"
 
     # intensity
-    _create_groupe(entry=entry, name="I", data=iq.intensity, units="1/cm")
+    _create_group(entry=entry, name="I", data=iq.intensity, units="1/cm")
 
     # errors
-    _create_groupe(entry=entry, name="Idev", data=iq.error, units="1/cm")
+    _create_group(entry=entry, name="Idev", data=iq.error, units="1/cm")
 
     # mod_q
     if iq.mod_q is not None:
-        _create_groupe(entry=entry, name="Q", data=iq.mod_q, units="1/A")
+        _create_group(entry=entry, name="Q", data=iq.mod_q, units="1/A")
 
         logger.debug(f"delta mod q: {iq.delta_mod_q}")
-        _create_groupe(entry=entry, name="Qdev", data=iq.delta_mod_q, units="1/A")
+        _create_group(entry=entry, name="Qdev", data=iq.delta_mod_q, units="1/A")
 
     # wavelength
     if iq.wavelength:
         wavelength = "{}".format(iq.wavelength)
-        _create_groupe(entry=entry, name="Wavelength", data=wavelength, units="A")
+        _create_group(entry=entry, name="Wavelength", data=wavelength, units="A")
 
 
 def __save_individual_i1d_annular_to_log(i1d=None, topEntry=None, entryNameExt=""):
@@ -358,18 +358,18 @@ def __save_individual_i1d_annular_to_log(i1d=None, topEntry=None, entryNameExt="
     entry.attrs["axes"] = "phi"
 
     # intensity
-    _create_groupe(entry=entry, name="I", data=i1d.intensity, units="1/cm")
+    _create_group(entry=entry, name="I", data=i1d.intensity, units="1/cm")
 
     # errors
-    _create_groupe(entry=entry, name="Idev", data=i1d.error, units="1/cm")
+    _create_group(entry=entry, name="Idev", data=i1d.error, units="1/cm")
 
     # phi
-    _create_groupe(entry=entry, name="phi", data=i1d.phi, units="degrees")
+    _create_group(entry=entry, name="phi", data=i1d.phi, units="degrees")
 
     # wavelength
     if i1d.wavelength:
         wavelength = "{}".format(i1d.wavelength)
-        _create_groupe(entry=entry, name="Wavelength", data=wavelength, units="A")
+        _create_group(entry=entry, name="Wavelength", data=wavelength, units="A")
 
 
 def _save_i1d_to_log(i1d=None, topEntry=None):

--- a/src/drtsans/reductionlog.py
+++ b/src/drtsans/reductionlog.py
@@ -364,7 +364,7 @@ def __save_individual_i1d_annular_to_log(i1d=None, topEntry=None, entryNameExt="
     _create_groupe(entry=entry, name="Idev", data=i1d.error, units="1/cm")
 
     # phi
-    _create_groupe(entry=entry, name="phi", data=i1d.mod_q, units="degrees")
+    _create_groupe(entry=entry, name="phi", data=i1d.phi, units="degrees")
 
     # wavelength
     if i1d.wavelength:

--- a/src/drtsans/save_ascii.py
+++ b/src/drtsans/save_ascii.py
@@ -58,6 +58,49 @@ def save_ascii_binned_1D(filename: str, title, *args, **kwargs):
             f.write("{:.6E}\n".format(dq[i]))
 
 
+def save_ascii_binned_1D_annular(filename: str, title, *args, **kwargs):
+    """Save I(phi) data in Ascii format
+
+    Parameters
+    ----------
+    filename
+        absolute path to output filename for the 1D I(phi) profile
+    title: str
+        title to be added on the first line
+    args: drtsans.dataobjects.I1DAnnular
+        output from 1D binning
+    kwargs:
+        intensity, error, phi - 1D numpy arrays of the same length, output from 1D binning
+    """
+    try:
+        kwargs.update(args[0]._asdict())
+    except AttributeError:
+        pass
+    # Read the value of skip_nan from kwargs or True as default
+    skip_nan = kwargs.get("skip_nan", True)
+    # Delete NaNs if requested
+    if skip_nan:
+        finites = np.isfinite(kwargs["intensity"])
+        phi = kwargs["phi"][finites]
+        intensity = kwargs["intensity"][finites]
+        error = kwargs["error"][finites]
+    else:
+        phi = kwargs["phi"]
+        intensity = kwargs["intensity"]
+        error = kwargs["error"]
+
+    # create directory if non-existent
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+
+    with open(filename, "w+") as f:
+        f.write("# " + title + "\n")
+        f.write("#phi (degrees)        I (1/cm)        dI (1/cm)\n")
+        for i in range(len(intensity)):
+            f.write("{:.6E}\t".format(phi[i]))
+            f.write("{:.6E}\t".format(intensity[i]))
+            f.write("{:.6E}\n".format(error[i]))
+
+
 def save_ascii_1D(wksp, title, filename):
     """Save the I(q) workspace in Ascii format
 

--- a/src/drtsans/save_ascii.py
+++ b/src/drtsans/save_ascii.py
@@ -21,7 +21,7 @@ def save_ascii_binned_1D(filename: str, title, *args, **kwargs):
         absolute path to output filename for the 1D I(Q) profile
     title: str
         title to be added on the first line
-    args: drtsans.dataobjects.IQmod
+    args: ~drtsans.dataobjects.IQmod
         output from 1D binning
     kwargs:
         intensity, error, mod_q, delta_mod_q - 1D numpy arrays of the same length, output from 1D binning
@@ -67,7 +67,7 @@ def save_ascii_binned_1D_annular(filename: str, title, *args, **kwargs):
         absolute path to output filename for the 1D I(phi) profile
     title: str
         title to be added on the first line
-    args: drtsans.dataobjects.I1DAnnular
+    args: ~drtsans.dataobjects.I1DAnnular
         output from 1D binning
     kwargs:
         intensity, error, phi - 1D numpy arrays of the same length, output from 1D binning

--- a/src/drtsans/stitch.py
+++ b/src/drtsans/stitch.py
@@ -1,5 +1,5 @@
 # local imports
-from drtsans.dataobjects import IQmod
+from drtsans.dataobjects import IQmod, I1DAnnular
 
 # third party imports
 from mantid.simpleapi import logger
@@ -231,6 +231,15 @@ def stitch_binned_profiles(iq1d_unbinned, iq1d_binned, reduction_config):
         one per wedge.
     """
     iq1d_combined_out = []
+
+    if isinstance(iq1d_binned[0][0], I1DAnnular):
+        # stitching of annular profiles is not supported, return empty combined profile(s)
+        iq1d_binned_main = iq1d_binned[0]
+        for ibinning in range(len(iq1d_binned_main)):
+            iq1d_combined = I1DAnnular(intensity=[], error=[], phi=[])
+            iq1d_combined_out.append(iq1d_combined)
+        logger.notice("Skipping stitching. Stitching of annular profiles is not supported.")
+        return iq1d_combined_out
 
     boundaries = get_stitch_boundaries(reduction_config, iq1d_unbinned, anisotropic=len(iq1d_binned[0]) > 1)
 

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -1000,7 +1000,7 @@ def reduce_single_configuration(
             )
 
             _inside_detectordata[fr_log_label] = {
-                "iq": i1d_main_out,
+                "i1d": i1d_main_out,
                 "iqxqy": iq2d_main_out,
             }
 

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -22,7 +22,7 @@ from drtsans import (
     subtract_background,  # noqa E402
 )  # noqa E402
 from drtsans.beam_finder import fbc_options_json, find_beam_center  # noqa E402
-from drtsans.dataobjects import save_iqmod  # noqa E402
+from drtsans.dataobjects import save_i1d  # noqa E402
 from drtsans.instruments import extract_run_number  # noqa E402
 from drtsans.iq import bin_all  # noqa E402
 from drtsans.load import resolve_slicing
@@ -1016,7 +1016,7 @@ def reduce_single_configuration(
                     add_suffix = f"_wedge_{j}"
                 add_suffix += fr_label
                 ascii_1D_filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_Iq")
-                save_iqmod(i1d_main_out[j], f"{ascii_1D_filename}.dat", skip_nan=skip_nan)
+                save_i1d(i1d_main_out[j], f"{ascii_1D_filename}.dat", skip_nan=skip_nan)
 
             current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
             output.append(current_output)

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -33,7 +33,7 @@ from drtsans.path import (  # noqa E402
     allow_overwrite,  # noqa E402
     registered_workspace,
 )
-from drtsans.plots import plot_IQazimuthal, plot_IQmod  # noqa E402
+from drtsans.plots import plot_IQazimuthal, plot_i1d  # noqa E402
 from drtsans.process_uncertainties import set_init_uncertainties  # noqa E402
 from drtsans.samplelogs import SampleLogs  # noqa E402
 from drtsans.save_2d import save_nexus, save_nist_dat  # noqa E402
@@ -1196,10 +1196,10 @@ def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None)
             if len(out.I1D_main) > 1:
                 add_suffix = f"_wedge_{j}"
             filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_Iq.png")
-            plot_IQmod(
+            plot_i1d(
                 [out.I1D_main[j]],
                 filename,
-                loglog=True,
+                log_scale=True,
                 backend="mpl",
                 errorbar_kwargs={"label": "main"},
             )

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -973,7 +973,7 @@ def reduce_single_configuration(
             assert iq1d_main_in_fr[frameskip_frame] is not None, "Input I(Q)      main input cannot be None."
             assert iq2d_main_in_fr[frameskip_frame] is not None, "Input I(qx, qy) main input cannot be None."
 
-            iq2d_main_out, iq1d_main_out = bin_i_with_correction(
+            iq2d_main_out, i1d_main_out = bin_i_with_correction(
                 iq1d_main_in_fr,
                 iq2d_main_in_fr,
                 frameskip_frame,
@@ -1000,7 +1000,7 @@ def reduce_single_configuration(
             )
 
             _inside_detectordata[fr_log_label] = {
-                "iq": iq1d_main_out,
+                "iq": i1d_main_out,
                 "iqxqy": iq2d_main_out,
             }
 
@@ -1010,15 +1010,15 @@ def reduce_single_configuration(
                 save_ascii_binned_2D(f"{filename}.dat", "I(Qx,Qy)", iq2d_main_out)
                 save_cansas_nx(iq2d_main_out.to_workspace(), f"{filename}.h5")
 
-            for j in range(len(iq1d_main_out)):
+            for j in range(len(i1d_main_out)):
                 add_suffix = ""
-                if len(iq1d_main_out) > 1:
+                if len(i1d_main_out) > 1:
                     add_suffix = f"_wedge_{j}"
                 add_suffix += fr_label
                 ascii_1D_filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_Iq")
-                save_iqmod(iq1d_main_out[j], f"{ascii_1D_filename}.dat", skip_nan=skip_nan)
+                save_iqmod(i1d_main_out[j], f"{ascii_1D_filename}.dat", skip_nan=skip_nan)
 
-            current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=iq1d_main_out)
+            current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
             output.append(current_output)
         # END binning loop over frame
 

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -82,7 +82,7 @@ __all__ = [
     "plot_reduction_output",
 ]
 
-IofQ_output = namedtuple("IofQ_output", ["I2D_main", "I1D_main"])
+I_output = namedtuple("I_output", ["I2D_main", "I1D_main"])
 
 
 def _get_configuration_file_parameters(sample_run, directory=None):
@@ -663,7 +663,7 @@ def reduce_single_configuration(
     Returns
     -------
     ~list
-        list of IofQ_output: ['I2D_main', 'I1D_main']
+        list of I_output: ['I2D_main', 'I1D_main']
 
     """
     # Process reduction input: configuration and etc.
@@ -1018,7 +1018,7 @@ def reduce_single_configuration(
                 ascii_1D_filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_Iq")
                 save_i1d(i1d_main_out[j], f"{ascii_1D_filename}.dat", skip_nan=skip_nan)
 
-            current_output = IofQ_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
+            current_output = I_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
             output.append(current_output)
         # END binning loop over frame
 

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -22,7 +22,7 @@ from drtsans import (
     subtract_background,  # noqa E402
 )  # noqa E402
 from drtsans.beam_finder import fbc_options_json, find_beam_center  # noqa E402
-from drtsans.dataobjects import save_i1d  # noqa E402
+from drtsans.dataobjects import save_i1d, I1DAnnular  # noqa E402
 from drtsans.instruments import extract_run_number  # noqa E402
 from drtsans.iq import bin_all  # noqa E402
 from drtsans.load import resolve_slicing
@@ -1010,12 +1010,17 @@ def reduce_single_configuration(
                 save_ascii_binned_2D(f"{filename}.dat", "I(Qx,Qy)", iq2d_main_out)
                 save_cansas_nx(iq2d_main_out.to_workspace(), f"{filename}.h5")
 
+            binning_suffix = "Iq"
+            if isinstance(i1d_main_out[0], I1DAnnular):
+                binning_suffix = "Iphi"
             for j in range(len(i1d_main_out)):
                 add_suffix = ""
                 if len(i1d_main_out) > 1:
                     add_suffix = f"_wedge_{j}"
                 add_suffix += fr_label
-                ascii_1D_filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_Iq")
+                ascii_1D_filename = os.path.join(
+                    output_dir, f"{outputFilename}{output_suffix}{add_suffix}_{binning_suffix}"
+                )
                 save_i1d(i1d_main_out[j], f"{ascii_1D_filename}.dat", skip_nan=skip_nan)
 
             current_output = I_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
@@ -1191,11 +1196,14 @@ def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None)
             qmax=qmax,
         )
         plt.clf()
+        binning_suffix = "Iq"
+        if isinstance(out.I1D_main[0], I1DAnnular):
+            binning_suffix = "Iphi"
         for j in range(len(out.I1D_main)):
             add_suffix = ""
             if len(out.I1D_main) > 1:
                 add_suffix = f"_wedge_{j}"
-            filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_Iq.png")
+            filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_{binning_suffix}.png")
             plot_i1d(
                 [out.I1D_main[j]],
                 filename,

--- a/src/drtsans/tof/eqsans/elastic_reference_normalization.py
+++ b/src/drtsans/tof/eqsans/elastic_reference_normalization.py
@@ -7,119 +7,122 @@ from typing import Optional
 
 import numpy as np
 
-from drtsans.dataobjects import IQazimuthal, IQmod, save_iqmod, verify_same_q_bins
+from drtsans.dataobjects import IQazimuthal, IQmod, verify_same_q_bins, I1DAnnular, save_i1d, getDataType, DataType
 
 __all__ = [
     "normalize_by_elastic_reference_all",
     "normalize_by_elastic_reference_1d",
     "normalize_by_elastic_reference_2d",
-    "determine_reference_wavelength_q1d_mesh",
-    "reshape_q_wavelength_matrix",
-    "build_i_of_q1d",
-    "determine_common_mod_q_range_mesh",
+    "determine_reference_wavelength_intensity_mesh",
+    "reshape_intensity_domain_meshgrid",
+    "build_i1d_from_intensity_domain_meshgrid",
+    "build_i1d_one_wl_from_intensity_domain_meshgrid",
+    "determine_common_domain_range_mesh",
 ]
 
 
 @dataclass
 class ReferenceWavelengths:
     """
-    Class for keeping track of reference wavelength for each momentum transfer Q (1D)
+    Class for keeping track of reference wavelength for each bin (Q or phi)
 
     Parameters
     ----------
-    q_values: ~numpy.ndarray
-        vector for Q
-    ref_wavelengths: ~numpy.ndarray
-        vector for reference wavelength vector for each Q
-    intensities: ~numpy.ndarray
-        vector for intensities of (Q, reference wavelength)
-    errors: ~numpy.ndarray
-        vector for errors of (Q, reference wavelength)
+    x_vec: ~numpy.ndarray
+        vector for Q or phi
+    ref_wl_vec: ~numpy.ndarray
+        vector for reference wavelength vector for each Q or phi
+    intensity_vec: ~numpy.ndarray
+        vector for intensities of (Q, reference wavelength) or (phi, reference wavelength)
+    error_vec: ~numpy.ndarray
+        vector for errors of (Q, reference wavelength) or (phi, reference wavelength)
     """
 
-    q_vec: np.ndarray
+    x_vec: np.ndarray
     ref_wl_vec: np.ndarray
     intensity_vec: np.ndarray
     error_vec: np.ndarray
 
 
-def reshape_q_wavelength_matrix(i_of_q: IQmod) -> tuple:
-    """Reshape I(Q) into a mesh grid of (Q, wavelength)
+def reshape_intensity_domain_meshgrid(i1d: IQmod | I1DAnnular) -> tuple:
+    """Reshape I(Q)/I(phi) into a mesh grid of (Q, wavelength) or (phi, wavelength)
 
     Parameters
     ----------
-    i_of_q: ~drtsans.dataobjects.IQmod
-        Input I(Q, wavelength) to find common Q range from
+    i1d: IQmod | I1DAnnular
+        Input I(Q, wavelength) or I(phi, wavelength) to find common range from
 
     Returns
     -------
     tuple
-        wavelength vector, q vector,  intensity (2D), error (2D), dq array (2D) or None
+        wavelength vector, Q/phi vector, intensity (2D), error (2D), dq array (2D) or None
 
     """
-    # Create a matrix for q, wavelength, intensity and error
-    if i_of_q.delta_x is None:
-        i_q_wl_matrix = np.array([i_of_q.x, i_of_q.wavelength, i_of_q.intensity, i_of_q.error])
+    # Create a matrix for Q/phi, wavelength, intensity and error
+    # x is either momentum transfer, Q, or azimuthal angle, phi
+    if i1d.delta_x is None:
+        i_x_wl_matrix = np.array([i1d.x, i1d.wavelength, i1d.intensity, i1d.error])
     else:
-        i_q_wl_matrix = np.array(
+        i_x_wl_matrix = np.array(
             [
-                i_of_q.x,
-                i_of_q.wavelength,
-                i_of_q.intensity,
-                i_of_q.error,
-                i_of_q.delta_x,
+                i1d.x,
+                i1d.wavelength,
+                i1d.intensity,
+                i1d.error,
+                i1d.delta_x,
             ]
         )
-    i_q_wl_matrix = i_q_wl_matrix.transpose()
+    i_x_wl_matrix = i_x_wl_matrix.transpose()
 
-    # Order by wavelength and momentum transfer (Q)
-    i_q_wl_matrix = i_q_wl_matrix[np.lexsort((i_q_wl_matrix[:, 1], i_q_wl_matrix[:, 0]))]
+    # Order by wavelength and x
+    i_x_wl_matrix = i_x_wl_matrix[np.lexsort((i_x_wl_matrix[:, 1], i_x_wl_matrix[:, 0]))]
 
-    # Unique wavelength and unique momentum transfer
-    wl_vector = np.unique(i_of_q.wavelength)
-    q_vector = np.unique(i_of_q.x)
-    # verify whether (q, wl) are on mesh grid by checking unique Q and wavelength
-    assert wl_vector.shape[0] * q_vector.shape[0] == i_of_q.intensity.shape[0]
+    # Unique wavelength and unique x
+    wl_vector = np.unique(i1d.wavelength)
+    x_vector = np.unique(i1d.x)
+    # verify whether (x, wl) are on mesh grid by checking unique x and wavelength
+    assert wl_vector.shape[0] * x_vector.shape[0] == i1d.intensity.shape[0]
 
     # Reformat
-    intensity_array = i_q_wl_matrix[:, 2].reshape((q_vector.shape[0], wl_vector.shape[0]))
-    error_array = i_q_wl_matrix[:, 3].reshape((q_vector.shape[0], wl_vector.shape[0]))
-    if i_of_q.delta_x is not None:
-        dq_array = i_q_wl_matrix[:, 4].reshape((q_vector.shape[0], wl_vector.shape[0]))
+    intensity_array = i_x_wl_matrix[:, 2].reshape((x_vector.shape[0], wl_vector.shape[0]))
+    error_array = i_x_wl_matrix[:, 3].reshape((x_vector.shape[0], wl_vector.shape[0]))
+    if i1d.delta_x is not None:
+        delta_x_array = i_x_wl_matrix[:, 4].reshape((x_vector.shape[0], wl_vector.shape[0]))
     else:
-        dq_array = None
+        delta_x_array = None
 
-    return wl_vector, q_vector, intensity_array, error_array, dq_array
+    return wl_vector, x_vector, intensity_array, error_array, delta_x_array
 
 
 def normalize_by_elastic_reference_all(
     i_of_q_2d, i_1d, ref_i_1d, output_wavelength_dependent_profile=False, output_dir=None
 ):
-    """Normalize I(Q2D) and I(Q1D) by elastic reference run
+    """Normalize I(Q2D) and I(1D) by elastic reference run
 
     Parameters
     ----------
     i_of_q_2d: ~drtsans.dataobjects.IQazimuthal
         Input I(Q2D, wavelength) to normalize
     i_1d: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
-        Input I(Q1D, wavelength) to normalize
+        Input I(Q1D, wavelength) or I(phi, wavelength) to normalize
     ref_i_1d: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
-        Input I(Q1D, wavelength) as elastic reference run
+        Input I(Q1D, wavelength) or I(phi, wavelength) as elastic reference run
     output_wavelength_dependent_profile: bool
-        If True then output Iq for each wavelength before and after k correction
+        If True then output I(1D) for each wavelength before and after k correction
     output_dir: str
-        output directory for Iq profiles
+        output directory for I(1D) profiles
 
     Returns
     -------
     tuple
-        normalized I(Q2D), normalized I(Q1D), K vector and delta K vector
+        normalized I(Q2D), normalized I(1D), K vector and delta K vector
     """
     # check i_of_q and ref_i_of_q shall have same binning
     if not verify_same_q_bins(i_1d, ref_i_1d, False, tolerance=1e-3):
-        raise RuntimeError("Input I(Q) and elastic reference I(Q) have different Q and wavelength binning")
+        raise RuntimeError("Input I(1D) and elastic reference I(1D) have different binning")
 
     wl_vec = np.unique(i_1d.wavelength)
+    # x is either momentum transfer, Q, or azimuthal angle, phi
     x_vec = np.unique(i_1d.x)
 
     # Calculate the normalization factor for each wavelength
@@ -140,17 +143,17 @@ def normalize_by_elastic_reference_all(
     return iq2d_wl, i1d_wl, k_vec, k_error_vec
 
 
-def calculate_elastic_reference_normalization(wl_vec, q_vec, ref_i_1d):
+def calculate_elastic_reference_normalization(wl_vec, x_vec, ref_i_1d):
     """Calculate the elastic reference normalization factor (K) for each wavelength
 
     Parameters
     ----------
     wl_vec: ~numpy.ndarray
-        Vector of wavelengths in I(Q) to normalize
-    q_vec: ~numpy.ndarray
-        Vector of Q:s in I(Q) to normalize
+        Vector of wavelengths in I(1D) to normalize
+    x_vec: ~numpy.ndarray
+        Vector of Q:s, or phi:s, in I(1D) to normalize
     ref_i_1d: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
-        Elastic reference run I(Q, wavelength)
+        Elastic reference run I(Q, wavelength) or I(phi, wavelength)
 
     Returns
     -------
@@ -158,15 +161,15 @@ def calculate_elastic_reference_normalization(wl_vec, q_vec, ref_i_1d):
         K vector and delta K vector
 
     """
-    # Reshape Q, wavelength, intensities and errors to unique 1D array or 2D array
-    _, _, ref_i_array, ref_error_array, _ = reshape_q_wavelength_matrix(ref_i_1d)
+    # Reshape Q/phi, wavelength, intensities and errors to unique 1D array or 2D array
+    _, _, ref_i_array, ref_error_array, _ = reshape_intensity_domain_meshgrid(ref_i_1d)
 
     # Calculate Qmin and Qmax
-    qmin_index, qmax_index = determine_common_mod_q_range_mesh(q_vec, ref_i_array)
+    qmin_index, qmax_index = determine_common_domain_range_mesh(x_vec, ref_i_array)
 
     # Calculate reference
-    ref_wl_ie = determine_reference_wavelength_q1d_mesh(
-        wl_vec, q_vec, ref_i_array, ref_error_array, qmin_index, qmax_index
+    ref_wl_ie = determine_reference_wavelength_intensity_mesh(
+        wl_vec, x_vec, ref_i_array, ref_error_array, qmin_index, qmax_index
     )
 
     # Calculate scale factor
@@ -178,76 +181,69 @@ def calculate_elastic_reference_normalization(wl_vec, q_vec, ref_i_1d):
 
 
 def normalize_by_elastic_reference_1d(
-    i_of_q: IQmod,
+    i1d: IQmod | I1DAnnular,
     k_vec: np.ndarray,
     k_error_vec: np.ndarray,
     output_wavelength_dependent_profile: bool = False,
     output_dir: Optional[str] = None,
-) -> IQmod:
-    """Normalize I(Q1D) by wavelength-dependent elastic reference normalization factor
+) -> IQmod | I1DAnnular:
+    """Normalize I(Q1D) or I(phi) by wavelength-dependent elastic reference normalization factor
 
     Parameters
     ----------
-    i_of_q: ~drtsans.dataobjects.IQmod
-        Input I(Q, wavelength) to normalize
+    i1d: IQmod | I1DAnnular
+        Input I(Q, wavelength) or I(phi, wavelength) to normalize
     k_vec: ~numpy.ndarray
         Elastic reference normalization factors (one for each wavelength)
     k_error_vec: ~numpy.ndarray
         Elastic reference normalization factor errors (one for each wavelength)
     output_wavelength_dependent_profile: bool
-        If True then output Iq for each wavelength before and after k correction
+        If True then output I for each wavelength before and after k correction
     output_dir: str
-        output directory for Iq profiles
+        output directory for intensity profiles
 
     Returns
     -------
     tuple
-        normalized Q(1D), K vector and delta K vector
+        normalized I(Q1D) or I(phi), K vector and delta K vector
 
     """
-    # Reshape Q, wavelength, intensities and errors to unique 1D array or 2D array
-    wl_vec, q_vec, i_array, error_array, dq_array = reshape_q_wavelength_matrix(i_of_q)
+    # Reshape Q/phi, wavelength, intensities and errors to unique 1D array or 2D array
+    wl_vec, x_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(i1d)
 
+    i1d_type = getDataType(i1d)
     if output_wavelength_dependent_profile and output_dir:
         for tmpwlii, wl in enumerate(wl_vec):
             tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat")
-            save_iqmod(
-                IQmod(
-                    intensity=i_array[:, tmpwlii],
-                    error=error_array[:, tmpwlii],
-                    mod_q=q_vec,
-                    delta_mod_q=dq_array[:, tmpwlii],
-                ),
-                tmpfn,
+            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
+                x_vec, i_array, error_array, dq_array, tmpwlii, i1d_type
             )
+            save_i1d(i1d_wl, tmpfn)
 
     # Normalize
-    normalized = normalize_intensity_q1d(
+    normalized = normalize_intensity_1d(
         wl_vec,
-        q_vec,
+        x_vec,
         i_array,
         error_array,
         k_vec,
         k_error_vec,
     )
 
-    # Convert normalized intensities and errors to IModQ
-    normalized_i_of_q = build_i_of_q1d(wl_vec, q_vec, normalized[0], normalized[1], dq_array)
+    # Convert normalized intensities and errors to object of type `i1d_type`
+    normalized_i1d = build_i1d_from_intensity_domain_meshgrid(
+        wl_vec, x_vec, normalized[0], normalized[1], dq_array, i1d_type
+    )
 
     if output_wavelength_dependent_profile and output_dir:
         for tmpwlii, wl in enumerate(wl_vec):
             tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat")
-            save_iqmod(
-                IQmod(
-                    intensity=normalized[0][:, tmpwlii],
-                    error=normalized[1][:, tmpwlii],
-                    mod_q=q_vec,
-                    delta_mod_q=dq_array[:, tmpwlii],
-                ),
-                tmpfn,
+            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
+                x_vec, normalized[0], normalized[1], dq_array, tmpwlii, i1d_type
             )
+            save_i1d(i1d_wl, tmpfn)
 
-    return normalized_i_of_q
+    return normalized_i1d
 
 
 def normalize_by_elastic_reference_2d(i_of_q, k_vec, k_error_vec):
@@ -310,36 +306,42 @@ def normalize_by_elastic_reference_2d(i_of_q, k_vec, k_error_vec):
     return normalized_i_of_q
 
 
-def build_i_of_q1d(wl_vector, q_vector, intensity_array, error_array, delta_q_array) -> IQmod:
-    """From wavelength, Q, intensity, error and delta Q to build I(Q1D)
+def build_i1d_from_intensity_domain_meshgrid(
+    wl_vector, x_vector, intensity_array, error_array, delta_q_array, i1d_type
+) -> IQmod | I1DAnnular:
+    """Build I(1D) from a mesh grid representation of intensity, error and delta Q
+    as a function of Q (or phi) and wavelength
 
-    This is the reversed operation to method reshape_q_wavelength_matrix
+    This is the reversed operation to method
+    :py:meth:`~drtsans.tof.eqsans.elastic_reference_normalization.reshape_intensity_domain_meshgrid`
 
     Parameters
     ----------
     wl_vector: ~numpy.ndarray
         wavelength (1D)
-    q_vector: ~numpy.ndarray
-        Q (1D)
+    x_vector: ~numpy.ndarray
+        Q or phi (1D)
     intensity_array: ~numpy.ndarray
         intensities (2D)
     error_array: ~numpy.ndarray
         intensity errors (2D)
     delta_q_array: ~numpy.ndarray
-        delta Q (1D) size = number wavelength * number Q
+        delta Q (1D) size = number wavelength * number Q, not used for i1d_type = DataType.I_ANNULAR
+    i1d_type: DataType
+        output data type for the intensity profile
 
     Returns
     -------
-    ~drtsans.dataobjects.IQmod
-        constructed I(Q, wavelength)
+    ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
+        constructed I(Q, wavelength) or I(phi, wavelength)
 
     """
     # assume that intensity, error and delta q have the same as (num_q, num_wl)
-    assert intensity_array.shape[0] == q_vector.shape[0] and intensity_array.shape[1] == wl_vector.shape[0]
+    assert intensity_array.shape[0] == x_vector.shape[0] and intensity_array.shape[1] == wl_vector.shape[0]
 
     # tile wave length
-    wl_array_1d = np.tile(wl_vector, q_vector.shape[0])
-    q_array_1d = np.repeat(q_vector, wl_vector.shape[0])
+    wl_array_1d = np.tile(wl_vector, x_vector.shape[0])
+    q_array_1d = np.repeat(x_vector, wl_vector.shape[0])
 
     # flatten intensity, error and optionally delta q
     intensity_array = intensity_array.flatten()
@@ -347,62 +349,117 @@ def build_i_of_q1d(wl_vector, q_vector, intensity_array, error_array, delta_q_ar
     if delta_q_array is not None:
         delta_q_array = delta_q_array.flatten()
 
-    return IQmod(
-        intensity=intensity_array,
-        error=error_array,
-        mod_q=q_array_1d,
-        wavelength=wl_array_1d,
-        delta_mod_q=delta_q_array,
-    )
+    if i1d_type == DataType.IQ_MOD:
+        i1d = IQmod(
+            intensity=intensity_array,
+            error=error_array,
+            mod_q=q_array_1d,
+            wavelength=wl_array_1d,
+            delta_mod_q=delta_q_array,
+        )
+    elif i1d_type == DataType.I_ANNULAR:
+        i1d = I1DAnnular(
+            intensity=intensity_array,
+            error=error_array,
+            phi=q_array_1d,
+            wavelength=wl_array_1d,
+        )
+    else:
+        raise TypeError(f"{i1d_type} is not supported")
+
+    return i1d
 
 
-def determine_common_mod_q_range_mesh(q_vec, intensity_array):
-    """Determine the common Q1D range among all the wavelengths such that I(q, lambda) does exist.
-
-    This method assumes that I(Q, wavelength) are on mesh grid of Q and wavelength
-
-    Detailed requirement:
-        Determine q_min and q_max  that exist in all I(q, lambda) for the fitting (minimization) process
+def build_i1d_one_wl_from_intensity_domain_meshgrid(
+    x_vector, intensity_array, error_array, delta_q_array, wl_index, i1d_type
+) -> IQmod | I1DAnnular:
+    """Build I(1D) for one wavelength from a mesh grid representation of intensity,
+    error and delta Q as a function of Q (or phi) and wavelength
 
     Parameters
     ----------
-    q_vec: numpy.ndarray
-        vector of sorted unique Q
+    x_vector: ~numpy.ndarray
+        Q or phi (1D)
+    intensity_array: ~numpy.ndarray
+        intensities (2D)
+    error_array: ~numpy.ndarray
+        intensity errors (2D)
+    delta_q_array: ~numpy.ndarray
+        delta Q (1D) size = number wavelength * number Q, not used for i1d_type = DataType.I_ANNULAR
+    wl_index: int
+        Wavelength axis index to extract
+    i1d_type: DataType
+        output data type for the intensity profile
+
+    Returns
+    -------
+    ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
+        constructed I(Q, wavelength) or I(phi, wavelength)
+
+    """
+    if i1d_type == DataType.IQ_MOD:
+        return IQmod(
+            intensity=intensity_array[:, wl_index],
+            error=error_array[:, wl_index],
+            mod_q=x_vector,
+            delta_mod_q=delta_q_array[:, wl_index],
+        )
+    elif i1d_type == DataType.I_ANNULAR:
+        return I1DAnnular(
+            intensity=intensity_array[:, wl_index],
+            error=error_array[:, wl_index],
+            phi=x_vector,
+        )
+    else:
+        raise TypeError(f"{i1d_type} is not supported")
+
+
+def determine_common_domain_range_mesh(x_vec, intensity_array):
+    """Determine the common Q or phi range among all the wavelengths such that I(Q/phi, lambda) does exist.
+
+    This method assumes that I(Q/phi, wavelength) are on mesh grid of Q/phi and wavelength
+
+    Detailed requirement:
+        Determine q_min and q_max that exist in all I(q, lambda) for the fitting (minimization) process
+
+    Parameters
+    ----------
+    x_vec: numpy.ndarray
+        vector of sorted unique Q or phi, depending on whether the 1D binning is scalar or annular
     intensity_array: numpy.ndarray
         2D array of intensity.  Each row is of same wavelength
 
     Returns
     -------
     tuple
-        index of qmin and qmax
+        index of x_min and x_max
 
     """
-    # Find q min
-    qmin_index = None
-    qmax_index = None
+    xmin_index = None
+    xmax_index = None
 
     # Sanity check
-    assert q_vec.shape[0] == intensity_array.shape[0], "Shape mismatch"
+    assert x_vec.shape[0] == intensity_array.shape[0], "Shape mismatch"
 
-    num_q = q_vec.shape[0]
-    for q_index in range(num_q):
-        if len(np.where(np.isnan(intensity_array[q_index]))[0]) == 0:
-            qmin_index = q_index
+    num_x = x_vec.shape[0]
+    for x_index in range(num_x):
+        if len(np.where(np.isnan(intensity_array[x_index]))[0]) == 0:
+            xmin_index = x_index
             break
-    for q_index in range(num_q - 1, -1, -1):
-        if len(np.where(np.isnan(intensity_array[q_index]))[0]) == 0:
-            qmax_index = q_index
+    for x_index in range(num_x - 1, -1, -1):
+        if len(np.where(np.isnan(intensity_array[x_index]))[0]) == 0:
+            xmax_index = x_index
             break
 
-    if qmin_index is None:
-        raise RuntimeError("Unable to find common q range")
+    if xmin_index is None:
+        raise RuntimeError("Unable to find common range")
 
-    return qmin_index, qmax_index
+    return xmin_index, xmax_index
 
 
-def calculate_scale_factor_mesh_grid(wl_vec, intensity_array, error_array, ref_wl_intensities, qmin_index, qmax_index):
+def calculate_scale_factor_mesh_grid(wl_vec, intensity_array, error_array, ref_wl_intensities, xmin_index, xmax_index):
     """Same functionality as calculate_scale_factor but the algorithm is improved
-    as I(Q, wavelength) are in meshgrid
+    as I(Q, wavelength) or I(phi, wavelength) are in meshgrid
 
     Parameters
     ----------
@@ -414,10 +471,10 @@ def calculate_scale_factor_mesh_grid(wl_vec, intensity_array, error_array, ref_w
         error 2D array
     ref_wl_intensities: ReferenceWavelengths
         reference wavelength intensity/error
-    qmin_index: int
-        index of min Q in q vector
-    qmax_index: int
-        index of max Q in q vector
+    xmin_index: int
+        index of min x in x vector (actually Q or phi)
+    xmax_index: int
+        index of max x in x vector (actually Q or phi)
 
     Returns
     -------
@@ -433,63 +490,64 @@ def calculate_scale_factor_mesh_grid(wl_vec, intensity_array, error_array, ref_w
     for i_wl, lambda_i in enumerate(wl_vec):
         # P(wl) = sum_q I(q, ref_wl) * I(q, wl)
         p_value = np.sum(
-            ref_wl_intensities.intensity_vec[qmin_index : qmax_index + 1]
-            * intensity_array[:, i_wl][qmin_index : qmax_index + 1]
+            ref_wl_intensities.intensity_vec[xmin_index : xmax_index + 1]
+            * intensity_array[:, i_wl][xmin_index : xmax_index + 1]
         )
         # S(wl) = sum_q I(q, wl)**2
-        s_value = np.sum(intensity_array[:, i_wl][qmin_index : qmax_index + 1] ** 2)
+        s_value = np.sum(intensity_array[:, i_wl][xmin_index : xmax_index + 1] ** 2)
 
         # Calculate K(wl)
         k_vec[i_wl] = p_value / s_value
 
         # Calculate K(wl) error
-        term0 = error_array[:, i_wl][qmin_index : qmax_index + 1]
+        term0 = error_array[:, i_wl][xmin_index : xmax_index + 1]
         term1 = (
-            ref_wl_intensities.intensity_vec[qmin_index : qmax_index + 1] * s_value
-            - 2.0 * intensity_array[:, i_wl][qmin_index : qmax_index + 1] * p_value
+            ref_wl_intensities.intensity_vec[xmin_index : xmax_index + 1] * s_value
+            - 2.0 * intensity_array[:, i_wl][xmin_index : xmax_index + 1] * p_value
         ) / s_value**2
-        term2 = ref_wl_intensities.error_vec[qmin_index : qmax_index + 1]
-        term3 = intensity_array[:, i_wl][qmin_index : qmax_index + 1] / s_value
+        term2 = ref_wl_intensities.error_vec[xmin_index : xmax_index + 1]
+        term3 = intensity_array[:, i_wl][xmin_index : xmax_index + 1] / s_value
 
         k_error2_vec[i_wl] = np.sum((term0 * term1) ** 2 + (term2 * term3) ** 2)
 
     return k_vec, np.sqrt(k_error2_vec)
 
 
-def determine_reference_wavelength_q1d_mesh(
+def determine_reference_wavelength_intensity_mesh(
     wavelength_vec,
-    q_vec,
+    x_vec,
     intensity_array,
     error_array,
-    qmin_index,
-    qmax_index,
+    xmin_index,
+    xmax_index,
     min_wl_index=0,
 ):
-    """Determine the reference wavelength for each Q.
+    """Determine the reference wavelength for each x (Q or phi).
 
-    The reference wavelength of a specific Q or (qx, qy)
+    The reference wavelength of a specific Q or (qx, qy) or phi
     is defined as the shortest wavelength for all the finite I(Q, wavelength) or
-    I(qx, qy, wavelength)
+    I(qx, qy, wavelength) or I(phi, wavelength)
 
     Parameters
     ----------
     wavelength_vec: numpy.ndarray
-        ...
-    q_vec: numpy.ndarray
-        ...
+        Wavelength vector
+    x_vec: numpy.ndarray
+        Vector of Q or phi
     intensity_array: numpy.ndarray
-        ...
+        Intensity array (2D)
     error_array: numpy.ndarray
-        ...
-    qmin_index: int
-        index of qmin in q-vector
-    qmax_index: int
-        index of qmax in q-vector
+        Error array (2D)
+    xmin_index: int
+        index of xmin in x-vector
+    xmax_index: int
+        index of xmax in x-vector
 
     Returns
     -------
     ReferenceWavelengths
-        Reference wavelengths for each momentum transfer Q and the corresponding intensity and error
+        Reference wavelengths for each momentum transfer Q, or azimuthal angle phi, and the
+        corresponding intensity and error
 
     """
     # Sanity check
@@ -498,42 +556,42 @@ def determine_reference_wavelength_q1d_mesh(
     )
 
     # Minimum wavelength bin is the reference wavelength
-    min_wl_vec = np.zeros_like(q_vec) + wavelength_vec[min_wl_index]
+    min_wl_vec = np.zeros_like(x_vec) + wavelength_vec[min_wl_index]
 
     # Minimum intensity and error
     min_intensity_vec = np.copy(intensity_array[:, min_wl_index])
     min_error_vec = np.copy(error_array[:, min_wl_index])
 
-    # Set the unused defined reference wavelength (outside of qmin and qmax)'s
+    # Set the unused defined reference wavelength (outside of xmin and xmax)'s
     # intensity and error to nan
-    min_intensity_vec[0:qmin_index] = np.nan
-    min_intensity_vec[qmax_index + 1 :] = np.nan
-    min_error_vec[0:qmin_index] = np.nan
-    min_error_vec[qmax_index + 1 :] = np.nan
+    min_intensity_vec[0:xmin_index] = np.nan
+    min_intensity_vec[xmax_index + 1 :] = np.nan
+    min_error_vec[0:xmin_index] = np.nan
+    min_error_vec[xmax_index + 1 :] = np.nan
 
-    return ReferenceWavelengths(q_vec, min_wl_vec, min_intensity_vec, min_error_vec)
+    return ReferenceWavelengths(x_vec, min_wl_vec, min_intensity_vec, min_error_vec)
 
 
-def normalize_intensity_q1d(
+def normalize_intensity_1d(
     wl_vec,
-    q_vec,
+    x_vec,
     intensity_array,
     error_array,
     k_vec,
     k_error_vec,
 ):
-    """Normalize Q1D intensities and errors
+    """Normalize 1D intensities and errors
 
     Parameters
     ----------
     wl_vec: ~numpy.ndarray
         1D vector of wavelength (in ascending order)
-    q_vec: ~numpy.ndarray
-        1D vector of Q (in ascending order)
+    x_vec: ~numpy.ndarray
+        1D vector of Q or phi (in ascending order)
     intensity_array: ~numpy.ndarray
-        2D array of intensities, shape[0] = number of Q, shape[1] = number of wavelength
+        2D array of intensities, shape[0] = number of Q or phi, shape[1] = number of wavelength
     error_array: ~numpy.ndarray
-        2D array of errors, shape[0] = number of Q, shape[1] = number of wavelength
+        2D array of errors, shape[0] = number of Q or phi, shape[1] = number of wavelength
     k_vec: ~numpy.ndarray
         calculated K vector
     k_error_vec: ~numpy.ndarray
@@ -542,13 +600,13 @@ def normalize_intensity_q1d(
     Returns
     -------
     tuple
-        normalized I(Q1D), normalized error(Q1D)
+        normalized I(1D), normalized error(1D)
 
     """
 
     # Sanity check
     assert wl_vec.shape[0] == intensity_array.shape[1]  # wavelength as lambda
-    assert q_vec.shape[0] == error_array.shape[0]  # points as q
+    assert x_vec.shape[0] == error_array.shape[0]  # points as Q or phi
     assert intensity_array.shape == error_array.shape
 
     # Normalized intensities

--- a/src/drtsans/tof/eqsans/incoherence_correction_1d.py
+++ b/src/drtsans/tof/eqsans/incoherence_correction_1d.py
@@ -6,27 +6,29 @@ inelastic scattering, for both 1D and 2D data (despite its name).
 # https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/issues/689
 # Step 3: Correct wave-dependent incoherence intensity for I(Q, wavelength)
 from drtsans.tof.eqsans.elastic_reference_normalization import (
-    reshape_q_wavelength_matrix,
-    determine_common_mod_q_range_mesh,
-    build_i_of_q1d,
-    determine_reference_wavelength_q1d_mesh,
+    build_i1d_from_intensity_domain_meshgrid,
+    build_i1d_one_wl_from_intensity_domain_meshgrid,
+    determine_common_domain_range_mesh,
+    determine_reference_wavelength_intensity_mesh,
+    reshape_intensity_domain_meshgrid,
 )
 from drtsans.tof.eqsans.incoherence_correction_2d import correct_incoherence_inelastic_2d
-from drtsans.dataobjects import IQmod, save_iqmod
+from drtsans.dataobjects import getDataType, DataType, save_i1d
 from collections import namedtuple
+from mantid.kernel import logger
 import numpy as np
 import os
 
 
-__all__ = ["correct_incoherence_inelastic_all", "correct_incoherence_inelastic_1d", "CorrectedIQ1D"]
+__all__ = ["correct_incoherence_inelastic_all", "correct_incoherence_inelastic_1d", "CorrectedI1D"]
 
 # Output of corrected 1D case
-CorrectedIQ1D = namedtuple("CorrectedIQ1D", "iq1d b_factor b_error")
+CorrectedI1D = namedtuple("CorrectedI1D", "i1d b_factor b_error")
 
 
 def correct_incoherence_inelastic_all(
     i_of_q_2d,
-    i_of_q_1d,
+    i1d,
     select_minimum_incoherence,
     intensity_weighted=False,
     qmin=None,
@@ -35,17 +37,17 @@ def correct_incoherence_inelastic_all(
     output_wavelength_dependent_profile=False,
     output_dir=None,
 ):
-    """Correct I(Q2D) and I(Q1D) accounting wavelength dependant incoherent inelastic scattering
+    """Correct I(Q2D) and I(1D) accounting wavelength dependant incoherent inelastic scattering
 
-    This is the envelope method for the complete workflow to correct I(Q1D) and I(Q2D) accounting
+    This is the envelope method for the complete workflow to correct I(1D) and I(Q2D) accounting
     wavelength-dependent incoherent inelastic scattering
 
     Parameters
     ----------
     i_of_q_2d: ~drtsans.dataobjects.IQazimuthal or None
         I(Q2D, wavelength) and error
-    i_of_q_1d: ~drtsans.dataobjects.IQmod
-        I(Q1D, wavelength) and error
+    i1d: ~drtsans.dataobjects.IQmod | ~drtsans.dataobjects.I1DAnnular
+        I(1D, wavelength) and error
     select_minimum_incoherence: bool
         flag to determine correction B by minimum incoherence
     intensity_weighted: bool
@@ -57,61 +59,63 @@ def correct_incoherence_inelastic_all(
     factor: float
         automatically determine the qmin qmax by checking the intensity profile
     output_wavelength_dependent_profile: bool
-        If True then output Iq for each wavelength before and after b correction
+        If True then output intensity profile for each wavelength before and after b correction
     output_dir: str
-        output directory for Iq profiles
+        output directory for intensity profiles
 
     Returns
     -------
-    tuple[CorrectedIQ2D, CorrectedIQ1D]
-        named tuple include ~drtsans.dataobjects.IQmod (corrected I(Q, wavelength)),  B vector, B error vector
+    tuple[CorrectedIQ2D, CorrectedI1D]
 
     """
 
-    # Convert to mesh grid I(Q) and delta I(Q)
-    wl_vec, q_vec, i_array, error_array, dq_array = reshape_q_wavelength_matrix(i_of_q_1d)
+    # Convert to mesh grid I(Q) and delta I(Q), or I(phi) for annular binning
+    # x is either Q or phi
+    wl_vec, x_vec, i_array, error_array, delta_x_array = reshape_intensity_domain_meshgrid(i1d)
 
     if qmin is not None and qmax is not None:
-        qmin_index, qmax_index = np.searchsorted(q_vec, [qmin, qmax])
-        qmax_index = min(qmax_index, len(q_vec) - 1)
+        xmin_index, xmax_index = np.searchsorted(x_vec, [qmin, qmax])
+        xmax_index = min(xmax_index, len(x_vec) - 1)
     else:
-        # determine q min and q max that exists in all I(q, wl)
-        qmin_index, qmax_index = determine_common_mod_q_range_mesh(q_vec, i_array)
+        # determine x min and x max that exists in all I(Q, wl) or I(phi, wl)
+        xmin_index, xmax_index = determine_common_domain_range_mesh(x_vec, i_array)
 
     if factor is not None:
-        print(f"Using automated (qmin, qmax) finder with factor={factor}")
-        qmin_index, qmax_index = tuneqmin(qmin_index, qmax_index, i_array, factor=factor)
+        logger.notice(f"Using automated (xmin, xmax) finder with factor={factor}")
+        xmin_index, xmax_index = tune_xmin(xmin_index, xmax_index, i_array, factor=factor)
 
-    print(
-        f"Incoherent correction using qmin={q_vec[qmin_index]} qmax={q_vec[qmax_index]} "
-        f"with qmin_index={qmin_index}, qmax_index={qmax_index}"
+    logger.notice(
+        f"Incoherent correction using xmin={x_vec[xmin_index]} xmax={x_vec[xmax_index]} "
+        f"with xmin_index={xmin_index}, xmax_index={xmax_index}"
     )
 
     # calculate B factors and errors
     b_array, ref_wl_ie, ref_wl_index = calculate_b_factors(
         wl_vec,
-        q_vec,
+        x_vec,
         i_array,
         error_array,
         select_minimum_incoherence,
-        qmin_index,
-        qmax_index,
+        xmin_index,
+        xmax_index,
         intensity_weighted=intensity_weighted,
     )
 
     # Correct 1D
+    i1d_type = getDataType(i1d)
     corrected_1d = correct_incoherence_inelastic_1d(
         wl_vec,
-        q_vec,
+        x_vec,
         i_array,
         error_array,
-        dq_array,
+        delta_x_array,
         b_array,
-        qmin_index,
-        qmax_index,
+        xmin_index,
+        xmax_index,
         ref_wl_ie,
         output_wavelength_dependent_profile,
         output_dir,
+        i1d_type,
     )
 
     # Correct 2D
@@ -125,115 +129,110 @@ def correct_incoherence_inelastic_all(
 
 def correct_incoherence_inelastic_1d(
     wl_vec,
-    q_vec,
+    x_vec,
     i_array,
     error_array,
-    dq_array,
+    delta_x_array,
     b_array,
-    qmin_index,
-    qmax_index,
+    xmin_index,
+    xmax_index,
     ref_wl_ie,
     output_wavelength_dependent_profile=False,
     output_dir=None,
+    i1d_type=DataType.IQ_MOD,
 ):
     """
     Parameters
     ----------
     wl_vec: ~numpy.ndarray
         1D vector of wavelength (in ascending order)
-    q_vec: ~numpy.ndarray
-        1D vector of Q (in ascending order)
+    x_vec: ~numpy.ndarray
+        1D vector of Q or phi (in ascending order)
     i_array: ~numpy.ndarray
-        2D array of intensities, shape[0] = number of Q, shape[1] = number of wavelength
+        2D array of intensities, shape[0] = number of Q or phi, shape[1] = number of wavelength
     error_array: ~numpy.ndarray
         2D array if intensity errors
-    dq_array: ~numpy.ndarray
-        2D array of errors, shape[0] = number of Q, shape[1] = number of wavelength
+    delta_x_array: ~numpy.ndarray
+        2D array of errors, shape[0] = number of Q or phi, shape[1] = number of wavelength
     b_array: ~numpy.ndarray
         incoherence inelastic correction factor B, row 0: B factor, row 1: delta B
-    qmin_index: int
-        index of minimum common q in q vector
-    qmax_index: int
-        index of maximum common q in q vector
+    xmin_index: int
+        index of minimum common Q or phi in x vector
+    xmax_index: int
+        index of maximum common Q or phi in x vector
     ref_wl_ie: ReferenceWavelength
         the reference wavelength data used to calculate B
     output_wavelength_dependent_profile: bool
         If True then output Iq for each wavelength before and after b correction
     output_dir: str
         output directory for Iq profiles
+    i1d_type: DataType
+        the data type of the 1D intensity profile to output
 
     Returns
     -------
-    CorrectedIQ1D
-        I(Q1D) with inelastic incoherent correction applied
+    CorrectedI1D
+        I(Q1D) or I(phi) with inelastic incoherent correction applied
     """
     if output_wavelength_dependent_profile and output_dir:
         for tmpwlii, wl in enumerate(wl_vec):
             tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_before_b_correction.dat")
-            save_iqmod(
-                IQmod(
-                    intensity=i_array[:, tmpwlii],
-                    error=error_array[:, tmpwlii],
-                    mod_q=q_vec,
-                    delta_mod_q=dq_array[:, tmpwlii],
-                ),
-                tmpfn,
+            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
+                x_vec, i_array, error_array, delta_x_array, tmpwlii, i1d_type
             )
+            save_i1d(i1d_wl, tmpfn)
 
     # correct intensities and errors
     corrected_intensities, corrected_errors = correct_intensity_error(
-        wl_vec, q_vec, i_array, error_array, b_array, qmin_index, qmax_index, ref_wl_ie
+        wl_vec, x_vec, i_array, error_array, b_array, xmin_index, xmax_index, ref_wl_ie
     )
 
     # construct the output and return
-    corrected_i_of_q = build_i_of_q1d(wl_vec, q_vec, corrected_intensities, corrected_errors, dq_array)
+    corrected_i1d = build_i1d_from_intensity_domain_meshgrid(
+        wl_vec, x_vec, corrected_intensities, corrected_errors, delta_x_array, i1d_type
+    )
 
     if output_wavelength_dependent_profile and output_dir:
         for tmpwlii, wl in enumerate(wl_vec):
             tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_after_b_correction.dat")
-            save_iqmod(
-                IQmod(
-                    intensity=corrected_intensities[:, tmpwlii],
-                    error=corrected_errors[:, tmpwlii],
-                    mod_q=q_vec,
-                    delta_mod_q=dq_array[:, tmpwlii],
-                ),
-                tmpfn,
+            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
+                x_vec, corrected_intensities, corrected_errors, delta_x_array, tmpwlii, i1d_type
             )
+            save_i1d(i1d_wl, tmpfn)
 
     corrected = {
-        "iq1d": corrected_i_of_q,
+        "i1d": corrected_i1d,
         "b_factor": b_array[0],
         "b_error": b_array[1],
     }
 
-    return CorrectedIQ1D(**corrected)
+    return CorrectedI1D(**corrected)
 
 
-def tuneqmin(qmin_idx, qmax_idx, i_arr, factor):
-    """get I(qmin_index) and I(qmax_index) from the default qmin_index and
-    qmax_index if I(qmin_index) > 10 * I(qmax_index), then qmin_index
-    = qmin_index + 1 repeat comparison until I(qmin_index) <= factor*
-    I(qmax_index)
+def tune_xmin(xmin_idx, xmax_idx, i_arr, factor):
+    """get I(xmin_index) and I(xmax_index) from the default xmin_index and
+    xmax_index if I(xmin_index) > 10 * I(xmax_index), then xmin_index
+    = xmin_index + 1 repeat comparison until I(xmin_index) <= factor*
+    I(xmax_index)
     """
-    assert qmin_idx < qmax_idx
+    assert xmin_idx < xmax_idx
 
-    imin = np.nansum(i_arr[qmin_idx])
-    imax = np.nansum(i_arr[qmax_idx])
+    imin = np.nansum(i_arr[xmin_idx])
+    imax = np.nansum(i_arr[xmax_idx])
     if imin > factor * imax:
-        return tuneqmin(qmin_idx + 1, qmax_idx, i_arr, factor)
+        return tune_xmin(xmin_idx + 1, xmax_idx, i_arr, factor)
 
-    return (qmin_idx, qmax_idx)
+    return (xmin_idx, xmax_idx)
 
 
 def calculate_b_factors(
     wl_vec,
-    q_vec,
+    x_vec,
     intensity_array,
     error_array,
     select_min_incoherence,
-    qmin_index,
-    qmax_index,
+    xmin_index,
+    xmax_index,
     intensity_weighted=False,
 ):
     """Determine reference wavelength and then calculate B factor, B error factor.
@@ -245,18 +244,18 @@ def calculate_b_factors(
     ----------
     wl_vec: ~numpy.ndarray
         wavelength vector
-    q_vec: ~numpy.ndarray
-        Q vector
+    x_vec: ~numpy.ndarray
+        Q or phi vector
     intensity_array: ~numpy.ndarray
         intenisty 2D array
     error_array: ~numpy.ndarray
         intensity error 2D array
     select_min_incoherence: bool
         flag to apply select minimum incoherence algorithm
-    qmin_index: int
-        index of minimum common q in q vector
-    qmax_index: int
-        index of maximum common q in q vector (included)
+    xmin_index: int
+        index of minimum common Q or phi
+    xmax_index: int
+        index of maximum common Q or phi (included)
     intensity_weighted: bool
         if set to true, the B factor is calculated using weighted function by intensity
     Returns
@@ -269,11 +268,11 @@ def calculate_b_factors(
     # Sanity check
     assert intensity_array.shape == error_array.shape
     assert wl_vec.shape[0] == intensity_array.shape[1]
-    assert q_vec.shape[0] == error_array.shape[0]
+    assert x_vec.shape[0] == error_array.shape[0]
 
     # determine the reference wavelength: minimum wavelength bin
-    ref_wl_ie = determine_reference_wavelength_q1d_mesh(
-        wl_vec, q_vec, intensity_array, error_array, qmin_index, qmax_index, 0
+    ref_wl_ie = determine_reference_wavelength_intensity_mesh(
+        wl_vec, x_vec, intensity_array, error_array, xmin_index, xmax_index, 0
     )
 
     # calculate b(lambda_i) and delta b(lambda_i) if it is final
@@ -281,8 +280,8 @@ def calculate_b_factors(
         wl_vec,
         intensity_array,
         error_array,
-        qmin_index,
-        qmax_index,
+        xmin_index,
+        xmax_index,
         ref_wl_ie,
         calculate_b_error=not select_min_incoherence,
         intensity_weighted=intensity_weighted,
@@ -293,13 +292,13 @@ def calculate_b_factors(
         # reselect reference wavelength to the wavelength bin with minimum b
         ref_wl_index = np.argmin(b_array[0])
         # (re)determine the reference wavelengths' intensities and errors
-        ref_wl_ie = determine_reference_wavelength_q1d_mesh(
+        ref_wl_ie = determine_reference_wavelength_intensity_mesh(
             wl_vec,
-            q_vec,
+            x_vec,
             intensity_array,
             error_array,
-            qmin_index,
-            qmax_index,
+            xmin_index,
+            xmax_index,
             ref_wl_index,
         )
         # (re)calculate b array
@@ -307,8 +306,8 @@ def calculate_b_factors(
             wl_vec,
             intensity_array,
             error_array,
-            qmin_index,
-            qmax_index,
+            xmin_index,
+            xmax_index,
             ref_wl_ie,
             calculate_b_error=True,
             intensity_weighted=intensity_weighted,
@@ -333,8 +332,8 @@ def calculate_b_error_b(
     wl_vec,
     intensity_array,
     error_array,
-    qmin_index,
-    qmax_index,
+    xmin_index,
+    xmax_index,
     ref_wavelengths,
     calculate_b_error,
     intensity_weighted=False,
@@ -345,16 +344,16 @@ def calculate_b_error_b(
     ----------
     wl_vec: ~numpy.ndarray
         1D vector of wavelength (in ascending order)
-    q_vec: ~numpy.ndarray
-        1D vector of Q (in ascending order)
+    x_vec: ~numpy.ndarray
+        1D vector of Q or phi (in ascending order)
     intensity_array: ~numpy.ndarray
-        2D array of intensities, shape[0] = number of Q, shape[1] = number of wavelength
+        2D array of intensities, shape[0] = number of Q or phi, shape[1] = number of wavelength
     error_array: ~numpy.ndarray
-        2D array of errors, shape[0] = number of Q, shape[1] = number of wavelength
-    qmin_index: int
-        index of common Q min (included)
-    qmax_index: int
-        index of common Q max (included)
+        2D array of errors, shape[0] = number of Q or phi, shape[1] = number of wavelength
+    xmin_index: int
+        index of common Q or phi min (included)
+    xmax_index: int
+        index of common Q or phi max (included)
     ref_wavelengths: ReferenceWavelengths
         instance of ReferenceWavelengths containing intensities and errors
     calculate_b_error: bool
@@ -383,15 +382,15 @@ def calculate_b_error_b(
         # Calculate B factors
         # b[wl] =
         # - 1/N sum_{q_k=q_min}^{q_max}(1/RefI(q_k)) * sum_{q_k=q_min}^{q_max} ([RefI(q_k) - I(q_k, wl)]/RefI(q_k))
-        num_q = qmax_index + 1 - qmin_index
-        # operation into a (num_q, num_wl) 2D array
+        num_x = xmax_index + 1 - xmin_index
+        # operation into a (num_x, num_wl) 2D array
 
         ref_intensity_vec = unumpy.uarray(
-            ref_wavelengths.intensity_vec[qmin_index : qmax_index + 1].reshape((num_q, 1)),
-            ref_wavelengths.error_vec[qmin_index : qmax_index + 1].reshape((num_q, 1)),
+            ref_wavelengths.intensity_vec[xmin_index : xmax_index + 1].reshape((num_x, 1)),
+            ref_wavelengths.error_vec[xmin_index : xmax_index + 1].reshape((num_x, 1)),
         )
         intensity_vec = unumpy.uarray(
-            intensity_array[qmin_index : qmax_index + 1, :], error_array[qmin_index : qmax_index + 1, :]
+            intensity_array[xmin_index : xmax_index + 1, :], error_array[xmin_index : xmax_index + 1, :]
         )
 
         b_vec = (ref_intensity_vec - intensity_vec) / ref_intensity_vec
@@ -403,40 +402,40 @@ def calculate_b_error_b(
         # Calculate B error (delta B) as an option
         if calculate_b_error:
             # delta b(wl)^2 = 1/N^2 sum_{q_k=qmin}^{qmax} [(delta I(q_k, ref_wl))^2 + (delta I(q_k, wl))^2]
-            # operation into a (num_q, num_wl) 2D array
+            # operation into a (num_x, num_wl) 2D array
             b_factor_array[1] = unumpy.std_devs(b_array)
 
     else:
         # Calculate B factors
         # b[wl] = - 1/N sum_{q_k=q_min}^{q_max} [RefI(q_k) - I(q_k, wl)]
-        num_q = qmax_index + 1 - qmin_index
-        # operation into a (num_q, num_wl) 2D array
+        num_x = xmax_index + 1 - xmin_index
+        # operation into a (num_x, num_wl) 2D array
         b_vec = (
-            ref_wavelengths.intensity_vec[qmin_index : qmax_index + 1].reshape((num_q, 1))
-            - intensity_array[qmin_index : qmax_index + 1, :]
+            ref_wavelengths.intensity_vec[xmin_index : xmax_index + 1].reshape((num_x, 1))
+            - intensity_array[xmin_index : xmax_index + 1, :]
         )
-        b_factor_array[0] = -1.0 / num_q * np.sum(b_vec, axis=0)
+        b_factor_array[0] = -1.0 / num_x * np.sum(b_vec, axis=0)
 
         # Calculate B error (delta B) as an option
         if calculate_b_error:
             # delta b(wl)^2 = 1/N^2 sum_{q_k=qmin}^{qmax} [(delta I(q_k, ref_wl))^2 + (delta I(q_k, wl))^2]
-            # operation into a (num_q, num_wl) 2D array
-            b2_vec = (ref_wavelengths.error_vec[qmin_index : qmax_index + 1].reshape((num_q, 1))) ** 2 + (
-                error_array[qmin_index : qmax_index + 1, :]
+            # operation into a (num_x, num_wl) 2D array
+            b2_vec = (ref_wavelengths.error_vec[xmin_index : xmax_index + 1].reshape((num_x, 1))) ** 2 + (
+                error_array[xmin_index : xmax_index + 1, :]
             ) ** 2
-            b_factor_array[1] = 1.0 / num_q * np.sqrt(b2_vec.sum(axis=0))
+            b_factor_array[1] = 1.0 / num_x * np.sqrt(b2_vec.sum(axis=0))
 
     return b_factor_array
 
 
 def correct_intensity_error(
     wavelength_vec,
-    q_vec,
+    x_vec,
     intensity_array,
     error_array,
     b_array2d,
-    qmin_index,
-    qmax_index,
+    xmin_index,
+    xmax_index,
     ref_wl_ie,
 ):
     """Correct intensity and error
@@ -445,16 +444,16 @@ def correct_intensity_error(
     ----------
     wavelength_vec: ~numpy.ndarray
         1D vector of wavelength (in ascending order)
-    q_vec: ~numpy.ndarray
-        1D vector of Q (in ascending order)
+    x_vec: ~numpy.ndarray
+        1D vector of Q or phi (in ascending order)
     intensity_array: ~numpy.ndarray
         2D array of intensities, shape[0] = number of Q, shape[1] = number of wavelength
     error_array: ~numpy.ndarray
         2D array of errors, shape[0] = number of Q, shape[1] = number of wavelength
-    qmin_index: int
-        index of common Q min (included)
-    qmax_index: int
-        index of common Q max (included)
+    xmin_index: int
+        index of minimum common Q or phi (included)
+    xmax_index: int
+        index of maximum common Q or phi (included)
     ref_wl_ie: ReferenceWavelengths
         instance of ReferenceWavelengths containing intensities and errors
     b_array2d: ~numpy.ndarray
@@ -470,14 +469,14 @@ def correct_intensity_error(
     # Sanity checks
     assert intensity_array.shape == error_array.shape
     assert wavelength_vec.shape[0] == intensity_array.shape[1]
-    assert q_vec.shape[0] == error_array.shape[0]
+    assert x_vec.shape[0] == error_array.shape[0]
     assert len(b_array2d.shape) == 2 and b_array2d.shape[0] == 2, (
         f"Expected input B and B error but not of shape {b_array2d.shape}"
     )
     assert b_array2d.shape[1] == wavelength_vec.shape[0]
 
     # Init data structure
-    num_common_q = qmax_index - qmin_index + 1
+    num_common_q = xmax_index - xmin_index + 1
     corrected_intensities = np.zeros_like(intensity_array)
     corrected_errors = np.zeros_like(error_array)
 
@@ -497,14 +496,14 @@ def correct_intensity_error(
             1.0
             / num_common_q**2
             * np.sum(
-                ref_wl_ie.error_vec[qmin_index : qmax_index + 1] ** 2
-                + error_array[qmin_index : qmax_index + 1, i_wl] ** 2
+                ref_wl_ie.error_vec[xmin_index : xmax_index + 1] ** 2
+                + error_array[xmin_index : xmax_index + 1, i_wl] ** 2
             )
         )
 
         # make correct term1 for those inside qmin and qmax
         # term1[q_j] = (error[q_j, wl]^2 * (1 - 2/N)
-        term1[qmin_index : qmax_index + 1] *= 1 - 2 / num_common_q
+        term1[xmin_index : xmax_index + 1] *= 1 - 2 / num_common_q
 
         # sum
         term1 += term2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1734,6 +1734,28 @@ def assert_wksp_equal(left, right, rtol=0, atol=0, err_msg=""):  # noqa: C901
             **kwargs,
         )
         assert_func(left.error, right.extractE().ravel(), err_msg=err_msg + "error", **kwargs)
+    elif id_left == DataType.WORKSPACE2D and id_right == DataType.I_ANNULAR:
+        units = left.getAxis(0).getUnit().caption()
+        assert units == "azimuthalAngle", '{}: Found units="{}" rather than "azimuthalAngle"'.format(err_msg, units)
+        assert_func(left.extractX().ravel(), right.phi, err_msg=err_msg + "phi", **kwargs)
+        assert_func(
+            left.extractY().ravel(),
+            right.intensity,
+            err_msg=err_msg + "intensity",
+            **kwargs,
+        )
+        assert_func(left.extractE().ravel(), right.error, err_msg=err_msg + "error", **kwargs)
+    elif id_left == DataType.I_ANNULAR and id_right == DataType.WORKSPACE2D:
+        units = right.getAxis(0).getUnit().caption()
+        assert units == "azimuthalAngle", '{}: Found units="{}" rather than "azimuthalAngle"'.format(err_msg, units)
+        assert_func(left.phi, right.extractX().ravel(), err_msg=err_msg + "phi", **kwargs)
+        assert_func(
+            left.intensity,
+            right.extractY().ravel(),
+            err_msg=err_msg + "intensity",
+            **kwargs,
+        )
+        assert_func(left.error, right.extractE().ravel(), err_msg=err_msg + "error", **kwargs)
     elif id_left == id_right:  # compare things that are the same type
         if id_left == DataType.WORKSPACE2D:
             # let mantid do all the work

--- a/tests/integration/drtsans/mono/biosans/test_annular_binning.py
+++ b/tests/integration/drtsans/mono/biosans/test_annular_binning.py
@@ -1,0 +1,101 @@
+# standard library imports
+import os
+
+# third party imports
+import pytest
+
+# local imports
+from drtsans.mono.biosans import load_all_files, reduce_single_configuration, plot_reduction_output
+from drtsans.redparams import reduction_parameters
+
+
+REDUCTION_INPUT = {
+    "schemaStamp": "2020-04-15T21:09:52.745905",
+    "instrumentName": "BIOSANS",
+    "iptsNumber": "24666",
+    "dataDirectories": None,
+    "sample": {
+        "runNumber": "8361",
+        "thickness": 0.1,
+        "transmission": {"runNumber": "8361", "value": None},
+    },
+    "background": {
+        "runNumber": "8359",
+        "transmission": {"runNumber": "8359", "value": None},
+    },
+    "emptyTransmission": {"runNumber": "8364", "value": None},
+    "beamCenter": {"runNumber": "8373"},
+    "outputFileName": "r8361_PorB3_15m",
+    "configuration": {
+        "wavelength": None,
+        "wavelengthSpread": None,
+        "sampleOffset": None,
+        "sampleApertureSize": 14.0,
+        "useDefaultMask": True,
+        "defaultMask": [
+            {"Pixel": "1-18,239-256"},
+            {"Bank": "18-24,42-48"},
+            {"Bank": "49", "Tube": "1"},
+            {"Bank": "88", "Tube": "4"},
+        ],
+        "useMaskBackTubes": False,
+        "normalization": "Monitor",
+        "normalizationResortToTime": False,
+        "sensitivityMainFileName": "Sens_f6368m4p0_bsSVP.nxs",
+        "sensitivityWingFileName": "Sens_f6380w1p4_bsSVP.nxs",
+        "useSolidAngleCorrection": True,
+        "blockedBeamRunNumber": None,
+        "useThetaDepTransCorrection": True,
+        "DBScalingBeamRadius": 40.0,
+        "mmRadiusForTransmission": None,
+        "absoluteScaleMethod": "standard",
+        "StandardAbsoluteScale": 2.094e-10,
+        "numMainQxQyBins": 100,
+        "numWingQxQyBins": 100,
+        "numMidrangeQxQyBins": 100,
+        "1DQbinType": "annular",
+        "QbinType": "linear",
+        "AnnularAngleBin": 1.0,
+        "numMainQBins": 100,
+        "numWingQBins": 100,
+        "numMidrangeQBins": 100,
+        "useErrorWeighting": False,
+        "QminMain": 0.003,
+        "QmaxMain": 0.045,
+        "QminWing": 0.03,
+        "QmaxWing": 0.9,
+        "QminMidrange": 0.03,
+        "QmaxMidrange": 0.9,
+        "overlapStitchQmin": [0.0325],
+        "overlapStitchQmax": [0.0425],
+    },
+}
+
+
+@pytest.mark.datarepo
+def test_reduce_single_configuration(datarepo_dir, temp_directory):
+    reduction_input = REDUCTION_INPUT.copy()
+    output_dir = temp_directory(prefix="test_annular_binning")
+    reduction_input["configuration"]["outputDir"] = output_dir
+    reduction_input["dataDirectories"] = datarepo_dir
+    reduction_input["configuration"]["sensitivityMainFileName"] = os.path.join(
+        datarepo_dir.biosans, "Sens_f6368m4p0_bsSVP.nxs"
+    )
+    reduction_input["configuration"]["sensitivityWingFileName"] = os.path.join(
+        datarepo_dir.biosans, "Sens_f6380w1p4_bsSVP.nxs"
+    )
+    reduction_input = reduction_parameters(parameters_particular=reduction_input, validate=True)
+
+    load_params = {}
+    loaded = load_all_files(
+        reduction_input,
+        prefix="BIOSANS_TEST_LOAD",
+        load_params=load_params,
+        path=datarepo_dir.biosans,
+    )
+    assert len(loaded.sample) == 1
+    output = reduce_single_configuration(loaded, reduction_input)
+    assert len(output) == 1
+    plot_reduction_output(output, reduction_input, loglog=False)
+    assert os.path.exists(os.path.join(output_dir, "1D", "r8361_PorB3_15m_1D.png"))
+    del output

--- a/tests/integration/drtsans/mono/gpsans/test_annular_binning.py
+++ b/tests/integration/drtsans/mono/gpsans/test_annular_binning.py
@@ -1,0 +1,75 @@
+import os
+
+import pytest
+
+from drtsans.mono.gpsans import (
+    load_all_files,
+    plot_reduction_output,
+    reduce_single_configuration,
+)
+from drtsans.redparams import reduction_parameters
+
+
+REDUCTION_INPUT = {
+    "instrumentName": "GPSANS",
+    "iptsNumber": "24727",
+    "sample": {"runNumber": "9166", "thickness": "0.1", "transmission": {"runNumber": "9178"}},
+    "outputFileName": "Al4",
+    "background": {"runNumber": "9165", "transmission": {"runNumber": "9177"}},
+    "beamCenter": {"runNumber": "9177"},
+    "emptyTransmission": {"runNumber": "9177"},
+    "configuration": {
+        "outputDir": "",
+        "maskFileName": "",
+        "useDefaultMask": True,
+        "defaultMask": ["{'Pixel':'1-10,247-256'}"],
+        "blockedBeamRunNumber": "",
+        "darkFileName": "",
+        "sensitivityFileName": "sens_c486_noBar.nxs",
+        "absoluteScaleMethod": "direct_beam",
+        "DBScalingBeamRadius": "40",
+        "StandardAbsoluteScale": "1",
+        "normalization": "Monitor",
+        "useSolidAngleCorrection": True,
+        "useThetaDepTransCorrection": True,
+        "mmRadiusForTransmission": "40",
+        "numQxQyBins": "180",
+        "1DQbinType": "annular",
+        "AnnularAngleBin": "1.0",
+        "QbinType": "linear",
+        "numQBins": "100",
+        "Qmin": "",
+        "Qmax": "",
+        "useErrorWeighting": False,
+        "useMaskBackTubes": False,
+        "wavelength": "1.23",
+        "wavelengthSpread": "",
+        "sampleToSi": "234.56",
+        "sampleDetectorDistance": "32.11",
+    },
+}
+
+
+@pytest.mark.datarepo
+def test_reduce_single_configuration(datarepo_dir, temp_directory):
+    reduction_input = REDUCTION_INPUT.copy()
+    output_dir = temp_directory(prefix="test_annular_binning")
+    reduction_input["configuration"]["outputDir"] = output_dir
+    reduction_input["dataDirectories"] = datarepo_dir
+    reduction_input["configuration"]["sensitivityFileName"] = os.path.join(
+        datarepo_dir.gpsans, "overwrite_gold_04282020", "sens_c486_noBar.nxs"
+    )
+    reduction_input = reduction_parameters(parameters_particular=reduction_input, validate=True)
+
+    loaded = load_all_files(
+        reduction_input,
+        prefix="GP_TEST_LOAD",
+        load_params=None,
+        path=datarepo_dir.gpsans,
+    )
+    assert len(loaded.sample) == 1
+    output = reduce_single_configuration(loaded, reduction_input)
+    assert len(output) == 1
+    plot_reduction_output(output, reduction_input, loglog=False, close_figures=True)
+    assert os.path.exists(os.path.join(output_dir, "1D", "Al4_1D.png"))
+    del output

--- a/tests/integration/drtsans/test_auto_wedge.py
+++ b/tests/integration/drtsans/test_auto_wedge.py
@@ -9,7 +9,7 @@ import numpy as np
 import os
 import matplotlib.pyplot as plt
 from drtsans.auto_wedge import _binInQAndAzimuthal, _fitQAndAzimuthal
-from drtsans.dataobjects import IQazimuthal, IQmod
+from drtsans.dataobjects import IQazimuthal, I1DAnnular
 from drtsans.determine_bins import determine_1d_linear_bins
 from drtsans import getWedgeSelection
 from drtsans.mono import biosans
@@ -349,7 +349,7 @@ def _create_2d_histogram_data():
 
     azimuthal_rings = []
     for i in range(intensity.shape[1]):
-        azimuthal_rings.append(IQmod(intensity=intensity.T[i], error=error.T[i], mod_q=azimuthal_bins))
+        azimuthal_rings.append(I1DAnnular(intensity=intensity.T[i], error=error.T[i], phi=azimuthal_bins))
 
     return q_bins, azimuthal_rings
 
@@ -442,8 +442,7 @@ def test_bin_into_q_and_azimuthal():
 
     for spectrum, spectrum_exp in zip(azimuthal_rings, azimuthal_rings_exp):
         assert spectrum.intensity.shape == spectrum_exp.intensity.shape
-        np.testing.assert_allclose(spectrum.mod_q, spectrum_exp.mod_q, atol=0.05, equal_nan=True)
-        assert spectrum.delta_mod_q is None
+        np.testing.assert_allclose(spectrum.phi, spectrum_exp.phi, atol=0.05, equal_nan=True)
 
         np.testing.assert_allclose(spectrum.intensity, spectrum_exp.intensity, atol=0.05, equal_nan=True)
         np.testing.assert_allclose(spectrum.error, spectrum_exp.error, atol=0.05, equal_nan=True)

--- a/tests/integration/drtsans/tof/eqsans/test_annular_binning.py
+++ b/tests/integration/drtsans/tof/eqsans/test_annular_binning.py
@@ -38,6 +38,7 @@ REDUCTION_INPUT = {
             "transmission": {"runNumber": "", "value": "1.0"},
         },
         "elasticReferenceBkgd": {"runNumber": "", "transmission": {"runNumber": "", "value": "0.9"}},
+        "outputWavelengthDependentProfile": True,
         "fluxMonitorRatioFile": "",
         "maskFileName": "/SNS/EQSANS/shared/NeXusFiles/EQSANS/2021B_mp/beamstop_mask_4m_ext.nxs",
         "mmRadiusForTransmission": 25,

--- a/tests/integration/drtsans/tof/eqsans/test_annular_binning.py
+++ b/tests/integration/drtsans/tof/eqsans/test_annular_binning.py
@@ -1,0 +1,95 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from drtsans.redparams import reduction_parameters
+from drtsans.tof.eqsans import load_all_files, reduce_single_configuration, plot_reduction_output
+
+
+REDUCTION_INPUT = {
+    "instrumentName": "EQSANS",
+    "iptsNumber": "27799",
+    "outputFileName": "agbe_125707_test1",
+    "sample": {"runNumber": "125707", "thickness": 1, "transmission": {"runNumber": "", "value": "1"}},
+    "schemaStamp": "2021-08-06T17:32:34.528330",
+    "dataDirectories": "",
+    "emptyTransmission": {"runNumber": "125701", "value": ""},
+    "background": {"runNumber": "", "transmission": {"runNumber": "", "value": ""}},
+    "beamCenter": {"runNumber": "125701"},
+    "configuration": {
+        "1DQbinType": "annular",
+        "AnnularAngleBin": 1.0,
+        "QbinType": "linear",
+        "Qmax": "",
+        "Qmin": "",
+        "StandardAbsoluteScale": 1,
+        "absoluteScaleMethod": "standard",
+        "beamFluxFileName": "/SNS/EQSANS/shared/instrument_configuration/bl6_flux_at_sample",
+        "cutTOFmax": 2000.0,
+        "cutTOFmin": 500.0,
+        "darkFileName": "/SNS/EQSANS/shared/NeXusFiles/EQSANS/2021B_mp/EQSANS_124667.nxs.h5",
+        "defaultMask": "",
+        "detectorOffset": "80",
+        "fitInelasticIncoh": True,
+        "elasticReference": {
+            "runNumber": "124680",
+            "thickness": "1.0",
+            "transmission": {"runNumber": "", "value": "1.0"},
+        },
+        "elasticReferenceBkgd": {"runNumber": "", "transmission": {"runNumber": "", "value": "0.9"}},
+        "fluxMonitorRatioFile": "",
+        "maskFileName": "/SNS/EQSANS/shared/NeXusFiles/EQSANS/2021B_mp/beamstop_mask_4m_ext.nxs",
+        "mmRadiusForTransmission": 25,
+        "normalization": "Total charge",
+        "numQBins": 100,
+        "numQxQyBins": 80,
+        "sampleApertureSize": 10,
+        "sampleOffset": "314.5",
+        "useDefaultMask": True,
+        "wavelengthStep": 0.1,
+        "wavelengthStepType": "constant Delta lambda",
+    },
+}
+
+
+@pytest.mark.datarepo
+def test_reduce_single_configuration(datarepo_dir, temp_directory):
+    """Test reduction workflow with annular binning
+
+    Note: applies elastic reference normalization and incoherent inelastic correction
+    """
+    reduction_input = REDUCTION_INPUT.copy()
+    output_dir = temp_directory(prefix="test_annular_binning")
+    reduction_input["configuration"]["outputDir"] = output_dir
+
+    datadir = Path(datarepo_dir.eqsans) / "test_corrections"
+    reduction_input["dataDirectories"] = str(datadir)
+    reduction_input["configuration"]["instrumentConfigurationDir"] = str(
+        Path(datarepo_dir.eqsans) / "instrument_configuration"
+    )
+    reduction_input["configuration"]["maskFileName"] = str(Path(datadir) / "beamstop_mask_4m_ext.nxs")
+    reduction_input["configuration"]["beamFluxFileName"] = str(
+        Path(datarepo_dir.eqsans) / "instrument_configuration" / "bl6_flux_at_sample.dat"
+    )
+    # Set darkFileName so that it will pass the validator, later set to None
+    reduction_input["configuration"]["darkFileName"] = "/bin/true"
+    reduction_input["configuration"]["sensitivityFileName"] = str(
+        Path(datadir) / "Sensitivity_patched_thinPMMA_4m_124972.nxs"
+    )
+
+    reduction_input = reduction_parameters(parameters_particular=reduction_input, validate=True)
+
+    reduction_input["configuration"]["darkFileName"] = None
+    loaded = load_all_files(
+        reduction_input,
+        prefix="EQ_TEST_LOAD",
+        load_params=None,
+    )
+    assert len(loaded.sample) == 1
+    output = reduce_single_configuration(loaded, reduction_input)
+    assert len(output) == 1
+    assert os.path.exists(os.path.join(output_dir, "agbe_125707_test1_Iphi.dat"))
+    plot_reduction_output(output, reduction_input)
+    assert os.path.exists(os.path.join(output_dir, "agbe_125707_test1_Iphi.png"))
+    del output

--- a/tests/unit/drtsans/mono/biosans/test_api.py
+++ b/tests/unit/drtsans/mono/biosans/test_api.py
@@ -688,15 +688,15 @@ def test_save_i1d_all(tmp_path, iqmod_dummy, output_files):
 
 def test_plot_reduction_output(monkeypatch):
     """Unit test for helper function plot_reduction_output."""
-    # Mock the plot_IQmod function
-    plot_IQmod_counter = 0
+    # Mock the plot_i1d function
+    plot_i1d_counter = 0
 
-    def mock_plot_IQmod(*args, **kwargs):
-        nonlocal plot_IQmod_counter
-        plot_IQmod_counter += 1
-        return "mock_plot_IQmod"
+    def mock_plot_i1d(*args, **kwargs):
+        nonlocal plot_i1d_counter
+        plot_i1d_counter += 1
+        return "mock_plot_i1d"
 
-    monkeypatch.setattr("drtsans.plots.api.plot_IQmod", mock_plot_IQmod)
+    monkeypatch.setattr("drtsans.plots.api.plot_i1d", mock_plot_i1d)
 
     # Mock the plot_IQ function
     plot_IQazimuthal_counter = 0
@@ -768,7 +768,7 @@ def test_plot_reduction_output(monkeypatch):
     plot_reduction_output(reduction_output, reduction_input)
 
     assert plot_IQazimuthal_counter == 3
-    assert plot_IQmod_counter == 3
+    assert plot_i1d_counter == 3
     assert allow_overwrite_counter == 2
 
 

--- a/tests/unit/drtsans/mono/biosans/test_api.py
+++ b/tests/unit/drtsans/mono/biosans/test_api.py
@@ -883,22 +883,22 @@ def test_get_sample_detectordata(has_midrange, iqmod1d, iqmod2d):
     )
 
     # test the contents of detector data
-    testing.assert_allclose(detector_data["combined"]["iq"][0], iqmod1d[-1])
-    testing.assert_allclose(detector_data["main_0"]["iq"][0], iqmod1d[0])
-    testing.assert_allclose(detector_data["wing_0"]["iq"][0], iqmod1d[0])
+    testing.assert_allclose(detector_data["combined"]["i1d"][0], iqmod1d[-1])
+    testing.assert_allclose(detector_data["main_0"]["i1d"][0], iqmod1d[0])
+    testing.assert_allclose(detector_data["wing_0"]["i1d"][0], iqmod1d[0])
     testing.assert_allclose(detector_data["main_0"]["iqxqy"], iqmod2d)
     testing.assert_allclose(detector_data["wing_0"]["iqxqy"], iqmod2d)
     if has_midrange:
-        testing.assert_allclose(detector_data["midrange_0"]["iq"][0], iqmod1d[0])
+        testing.assert_allclose(detector_data["midrange_0"]["i1d"][0], iqmod1d[0])
         testing.assert_allclose(detector_data["midrange_0"]["iqxqy"], iqmod2d)
     else:
         assert "midrange_0" not in detector_data
 
     if len(iqmod1d) == 2:  # case when "1DQbinType" is "wedge"
-        testing.assert_allclose(detector_data["main_1"]["iq"][0], iqmod1d[1])
-        testing.assert_allclose(detector_data["wing_1"]["iq"][0], iqmod1d[1])
+        testing.assert_allclose(detector_data["main_1"]["i1d"][0], iqmod1d[1])
+        testing.assert_allclose(detector_data["wing_1"]["i1d"][0], iqmod1d[1])
         if has_midrange:
-            testing.assert_allclose(detector_data["midrange_1"]["iq"][0], iqmod1d[1])
+            testing.assert_allclose(detector_data["midrange_1"]["i1d"][0], iqmod1d[1])
         else:
             assert "midrange_1" not in detector_data
 

--- a/tests/unit/drtsans/mono/biosans/test_api.py
+++ b/tests/unit/drtsans/mono/biosans/test_api.py
@@ -13,14 +13,14 @@ import drtsans.plots.api
 from drtsans.samplelogs import SampleLogs
 from os.path import join as path_join
 
-from drtsans.dataobjects import IQazimuthal, IQmod, testing
+from drtsans.dataobjects import IQazimuthal, IQmod, testing, I1DAnnular
 from drtsans.mono.biosans.api import (
     load_all_files,
     prepare_data_workspaces,
     prepare_data,
     process_single_configuration,
     file_has_midrange_detector,
-    save_iqmod_all,
+    save_i1d_all,
     plot_reduction_output,
     check_overlap_stitch_configuration,
     get_sample_detectordata,
@@ -667,14 +667,19 @@ def test_has_midrange_detector(has_sns_mount):
                 "output_1D_combined_wedge_1.txt",
             ],
         ),
+        # case with I1DAnnular
+        (
+            [I1DAnnular(intensity=[], error=[], phi=[])],
+            ["output_1D_main.txt", "output_1D_midrange.txt", "output_1D_wing.txt", "output_1D_combined.txt"],
+        ),
     ],
 )
-def test_save_iqmod_all(tmp_path, iqmod_dummy, output_files):
+def test_save_i1d_all(tmp_path, iqmod_dummy, output_files):
     output_dir = path_join(tmp_path, "1D")
     if not os.path.exists(output_dir):
         os.mkdir(output_dir)
 
-    save_iqmod_all(iqmod_dummy, iqmod_dummy, iqmod_dummy, iqmod_dummy, "output", tmp_path, "", True)
+    save_i1d_all(iqmod_dummy, iqmod_dummy, iqmod_dummy, iqmod_dummy, "output", tmp_path, "", True)
 
     for filename in output_files:
         filepath = path_join(output_dir, filename)

--- a/tests/unit/drtsans/test_dataobjects.py
+++ b/tests/unit/drtsans/test_dataobjects.py
@@ -7,6 +7,7 @@ from drtsans.dataobjects import (
     concatenate,
     IQazimuthal,
     IQmod,
+    I1DAnnular,
     load_iqmod,
     save_iqmod,
     testing,
@@ -42,6 +43,14 @@ def test_concatenate():
     assert iq.qy == pytest.approx([10, 11, 12, 13, 14, 15, 16, 17, 18])
     assert iq.delta_qx is None
     assert iq.delta_qy is None
+    assert iq.wavelength is None
+    # test with I1DAnnular objects
+    iq1 = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+    iq2 = I1DAnnular([4, 5, 6], [4, 5, 6], [7, 8, 9], wavelength=[10, 11, 12])
+    iq3 = I1DAnnular([7, 8, 9], [4, 5, 6], [7, 8, 9])
+    iq = concatenate((iq1, iq2, iq3))
+    assert iq.intensity == pytest.approx([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    assert iq.phi == pytest.approx([7, 8, 9, 7, 8, 9, 7, 8, 9])
     assert iq.wavelength is None
 
 
@@ -617,6 +626,80 @@ class TestIQazimuthal:
         )
 
         assert CompareWorkspaces(ws, ws_expected).Result is True
+
+
+class TestI1DAnnular:
+    def test_to_from_csv(self):
+        i1d = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        filename = tempfile.NamedTemporaryFile("wb", suffix=".dat").name
+        i1d.to_csv(filename)
+        i1d_other = I1DAnnular.read_csv(filename)
+        testing.assert_allclose(i1d, i1d_other)
+        os.remove(filename)
+
+    def test_I1DAnnular_creation(self):
+        # these are expected to work
+        I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12])
+        I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9], wavelength=[13, 14, 15])
+
+        # intensity isn't 1d
+        with pytest.raises(TypeError):
+            I1DAnnular([[1, 2], [3, 4]], [4, 5, 6], [7, 8, 9])
+
+        # arrays are not parallel
+        with pytest.raises(TypeError):
+            I1DAnnular([1, 3], [4, 5, 6], [7, 8, 9])
+        with pytest.raises(TypeError):
+            I1DAnnular([1, 2, 3], [4, 6], [7, 8, 9])
+        with pytest.raises(TypeError):
+            I1DAnnular([1, 2, 3], [4, 5, 6], [7, 9])
+
+        # not enough arguments
+        with pytest.raises(TypeError):
+            I1DAnnular([1, 2, 3], [4, 5, 6])
+
+    def test_mul(self):
+        i1d = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        i1d = 2.5 * i1d
+        assert i1d.intensity == pytest.approx([2.5, 5, 7.5])
+        i1d = i1d * 2
+        assert i1d.intensity == pytest.approx([5, 10, 15])
+
+    def test_truediv(self):
+        i1d = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        i1d = i1d / 2
+        assert i1d.error == pytest.approx([2, 2.5, 3])
+
+    def test_extract(self):
+        i1d = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        i1d_2 = i1d.extract(2)
+        assert i1d_2.phi == pytest.approx(9)
+        i1d_2 = i1d.extract(slice(None, None, 2))
+        assert i1d_2.intensity == pytest.approx([1, 3])
+        i1d_2 = i1d.extract(i1d.phi < 9)
+        assert i1d_2.error == pytest.approx([4, 5])
+
+    def test_concatenate(self):
+        i1d = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        i1d_2 = i1d.concatenate(I1DAnnular([4, 5], [7, 8], [10, 11]))
+        assert i1d_2.phi == pytest.approx([7, 8, 9, 10, 11])
+
+    def test_sort(self):
+        i1d = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 9, 8])
+        i1d = i1d.sort()
+        assert i1d.phi == pytest.approx([7, 8, 9])
+        assert i1d.intensity == pytest.approx([1, 3, 2])
+
+    def test_I1DAnnular_to_mtd(self, clean_workspace):
+        # create the data object
+        i1d = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        # convert to mantid workspace
+        wksp = i1d.to_workspace()
+        clean_workspace(wksp)
+
+        # verify results
+        assert_wksp_equal(wksp, i1d)
 
 
 class TestTesting:

--- a/tests/unit/drtsans/test_dataobjects.py
+++ b/tests/unit/drtsans/test_dataobjects.py
@@ -281,6 +281,44 @@ def test_verify_same_bins():
         verify_same_q_bins(iq1d0, iq2d0)
 
 
+def test_verify_same_phi_bins():
+    """Test method verify_same_q_bins for I1DAnnular objects"""
+    # Test I1DAnnular without wavelength
+    iphi1d0 = I1DAnnular([1, 2, 3], [4, 5, 6], [7, 8, 9])
+    iphi1d1 = I1DAnnular([4, 9, 3], [4, 5, 6], [7, 8, 9])
+    assert verify_same_q_bins(iphi1d0, iphi1d1)
+
+    # Test I1DAnnular with wavelength
+    iphi1d0 = I1DAnnular(
+        [1, 2, 3, 4, 6, 6],
+        [4, 5, 6, 4, 5, 6],
+        [7, 8, 9, 7, 8, 9],
+        wavelength=[10, 10, 10, 11, 11, 11],
+    )
+    iphi1d1 = I1DAnnular(
+        [4, 9, 3, 8, 7, 6],
+        [4, 5, 6, 4, 5, 6],
+        [7, 8, 9, 7, 8, 9],
+        wavelength=[10, 10, 10, 11, 11, 11],
+    )
+    assert verify_same_q_bins(iphi1d0, iphi1d1)
+
+    # Test I1DAnnular with wavelength
+    iphi1d0 = I1DAnnular(
+        [1, 2, 3, 4, 6, 6],
+        [4, 5, 6, 4, 5, 6],
+        [7, 8, 9, 7, 8, 9],
+        wavelength=[10.1, 10.1, 10.1, 11, 11, 11],
+    )
+    iphi1d1 = I1DAnnular(
+        [4, 9, 3, 8, 7, 6],
+        [4, 5, 6, 4, 5, 6],
+        [7, 8, 9, 7, 8, 9],
+        wavelength=[10, 10, 10, 11, 11, 11],
+    )
+    assert verify_same_q_bins(iphi1d0, iphi1d1) is False
+
+
 def test_save_load_iqmod_dq():
     """Test save and load I(Q) to and from ASCII with Q, I(Q), dI(Q) and delta Q
 

--- a/tests/unit/drtsans/test_i_of_q_annular_binning.py
+++ b/tests/unit/drtsans/test_i_of_q_annular_binning.py
@@ -152,7 +152,7 @@ def test_1d_flat_data_wl():
     np.testing.assert_allclose(binned_i1d_wl.error, 0.6, atol=0.11)
     np.testing.assert_allclose(binned_i1d_no_wl.error, 0.4, atol=0.12)
     # actually the azimuthal angle
-    np.testing.assert_equal(binned_i1d_wl.mod_q, np.tile(np.arange(10.0, 360.0, 20.0), num_wl))
+    np.testing.assert_equal(binned_i1d_wl.phi, np.tile(np.arange(10.0, 360.0, 20.0), num_wl))
 
 
 def test_1d_wavelengths():
@@ -183,10 +183,10 @@ def test_1d_wavelengths():
     assert np.nanmin(binned_i1d_wl.error) == pytest.approx(2.9155, rel=1e-4)
     assert np.nanmax(binned_i1d_wl.error) == pytest.approx(5.0662, rel=1e-4)
     # actually the azimuthal angle
-    np.testing.assert_equal(binned_i1d_wl.mod_q, np.tile(np.arange(10.0, 360.0, 20.0), num_wl))
+    np.testing.assert_equal(binned_i1d_wl.phi, np.tile(np.arange(10.0, 360.0, 20.0), num_wl))
 
     # verify one bin
-    assert binned_i1d_wl.mod_q[3] == pytest.approx(70.0, rel=1e-4)
+    assert binned_i1d_wl.phi[3] == pytest.approx(70.0, rel=1e-4)
     assert binned_i1d_wl.intensity[3] == pytest.approx(59.0, rel=1e-4)
     assert binned_i1d_wl.error[3] == pytest.approx(4.4347, rel=1e-4)
     assert binned_i1d_wl.wavelength[3] == pytest.approx(1.5, rel=1e-4)

--- a/tests/unit/drtsans/test_i_of_q_annular_binning.py
+++ b/tests/unit/drtsans/test_i_of_q_annular_binning.py
@@ -51,11 +51,7 @@ def test_1d_annular_no_wt():
     # Verify I(Q), sigma I(Q) and dQ
     assert binned_iq.intensity[1] == pytest.approx(63.66666667, abs=1e-8), "Binned intensity is wrong"
     assert binned_iq.error[1] == pytest.approx(3.257470048, abs=1e-8), "Binned sigma I is wrong"
-    assert binned_iq.delta_mod_q[1] == pytest.approx(1.154e-02, abs=1e-5), (
-        "Binned Q resolution {} is incorrect comparing to {}.".format(binned_iq.delta_mod_q[1], 0.01154)
-    )
-    # this is actually phi
-    np.testing.assert_almost_equal(binned_iq.mod_q, np.linspace(start=18, stop=phi_max - 18, num=num_bins))
+    np.testing.assert_almost_equal(binned_iq.phi, np.linspace(start=18, stop=phi_max - 18, num=num_bins))
 
 
 def test_1d_annular_out_of_range_angles():
@@ -112,7 +108,7 @@ def test_1d_flat_data():
     # uncertainties are proportional to the number of input bins contributing to the annular wedge
     np.testing.assert_allclose(binned_iq.error, 0.6, atol=0.11)
     # actually the azimuthal angle
-    np.testing.assert_equal(binned_iq.mod_q, np.arange(10.0, 360.0, 20.0))
+    np.testing.assert_equal(binned_iq.phi, np.arange(10.0, 360.0, 20.0))
 
 
 def test_1d_flat_data_wl():

--- a/tests/unit/drtsans/test_i_of_q_binning_all.py
+++ b/tests/unit/drtsans/test_i_of_q_binning_all.py
@@ -205,7 +205,7 @@ def test_annular():
     )
     binned1d = binned1d[0]
     assert binned1d.intensity == pytest.approx([10.5, 14.5, 18.5, 22.5])
-    assert binned1d.mod_q == pytest.approx(np.arange(45, 360, 90))
+    assert binned1d.phi == pytest.approx(np.arange(45, 360, 90))
 
 
 def test_wedges():

--- a/tests/unit/drtsans/test_save_ascii.py
+++ b/tests/unit/drtsans/test_save_ascii.py
@@ -1,5 +1,5 @@
-from drtsans.dataobjects import IQazimuthal
-from drtsans.save_ascii import load_ascii_binned_2D, save_ascii_binned_2D
+from drtsans.dataobjects import IQazimuthal, I1DAnnular
+from drtsans.save_ascii import load_ascii_binned_2D, save_ascii_binned_2D, save_ascii_binned_1D_annular
 import numpy as np
 from pathlib import Path
 import pytest
@@ -67,6 +67,50 @@ def test_ascii_binned_2D_roundtrip(with_resolution):
 
     # cleanup - not using fixture so failures can be inspected
     filename.unlink()
+
+
+def assert_I1DAnnular_allclose(data1d_exp, data1d_obs, err_msg=""):
+    if err_msg:
+        err_msg += " "
+    for key in ["intensity", "error", "phi"]:
+        exp = getattr(data1d_exp, key)
+        obs = getattr(data1d_obs, key)
+        if exp is None or obs is None:
+            assert exp == obs, "{} are not both None".format(key)
+        else:
+            np.testing.assert_allclose(exp, obs, err_msg="{}{} doesn't match".format(err_msg, key))
+
+
+def test_save_ascii_annular():
+    # create test data
+    data1d = I1DAnnular(
+        intensity=[1, 2, 3],
+        error=[4, 5, 6],
+        phi=[7, 8, 9],
+    )
+
+    # file to write to
+    filename = Path(NamedTemporaryFile(suffix=".dat").name)
+
+    # write out the data
+    print("writing data to", filename)
+    save_ascii_binned_1D_annular(filename, "test data", data1d)
+    assert filename.exists()
+
+    # read the data back in
+    print("reading data from", filename)
+    csv_data = np.genfromtxt(filename, comments="#", dtype=np.float64, skip_header=2)
+    num_cols = len(csv_data[0])
+    assert num_cols == 3, "Incompatible number of columns: should be 3"
+    data1d_reread = I1DAnnular(
+        phi=csv_data[:, 0],
+        intensity=csv_data[:, 1],
+        error=csv_data[:, 2],
+    )  # wavelength isn't in the file
+    del csv_data
+
+    # validate the data is unchanged
+    assert_I1DAnnular_allclose(data1d, data1d_reread)
 
 
 if __name__ == "__main__":

--- a/tests/unit/drtsans/test_savereductionlog.py
+++ b/tests/unit/drtsans/test_savereductionlog.py
@@ -12,6 +12,7 @@ from tests.unit.drtsans.i_of_q_binning_tests_data import (
 )
 from drtsans.dataobjects import IQmod
 from drtsans.dataobjects import IQazimuthal
+from drtsans.dataobjects import I1DAnnular
 from tempfile import NamedTemporaryFile
 from drtsans import __version__ as drtsans_version
 from mantid import __version__ as mantid_version
@@ -68,6 +69,17 @@ def _create_iq():
     test_iq = IQmod(intensities, sigmas, scalar_q_array, scalar_dq_array)
 
     return test_iq
+
+
+def _create_i1d_annular():
+    # Get data
+    intensities, sigmas, phi, _ = generate_test_data(1, True)
+    test_i1d_annular = I1DAnnular(
+        intensity=intensities,
+        error=sigmas,
+        phi=phi,
+    )
+    return test_i1d_annular
 
 
 def _create_iqxqy():
@@ -269,6 +281,29 @@ def test_writing_iq_scalar_mode(cleanfile):
 
         data = iq_nxdata["Qdev"][:]
         _test_data(tested_data=data, ref_data=np.array([0.011912, 0.11912]), abs=1e-6)
+
+
+def test_writing_iq1d_annular(cleanfile):
+    test_i1d = [_create_i1d_annular()]
+    tmp_log_filename = _create_tmp_log_filename()
+    cleanfile(tmp_log_filename)
+    savereductionlog(tmp_log_filename, detectordata={"slice_1": {"main_detector": {"i1d": test_i1d}}})
+
+    assert os.path.exists(tmp_log_filename), "log file {} does not exist".format(tmp_log_filename)
+
+    with h5py.File(tmp_log_filename, "r") as handle:
+        top_group = _getGroup(handle, "slice_1", "NXdata")
+        mid_group = _getGroup(top_group, "main_detector", "NXdata")
+        i1d_nxdata = _getGroup(mid_group, "I(phi)", "NXdata")
+
+        data = i1d_nxdata["I"][:]
+        _test_data(tested_data=data, ref_data=np.array([93, 60]))
+
+        data = i1d_nxdata["Idev"][:]
+        _test_data(tested_data=data, ref_data=np.array([9.64365076, 7.74596669]), abs=1e-7)
+
+        data = i1d_nxdata["phi"][:]
+        _test_data(tested_data=data, ref_data=np.array([0.0078897, 0.0059338]), abs=1e-7)
 
 
 def test_slicelogdata_is_a_dict(cleanfile):

--- a/tests/unit/drtsans/test_savereductionlog.py
+++ b/tests/unit/drtsans/test_savereductionlog.py
@@ -148,7 +148,7 @@ def test_writing_metadata_with_no_reductionparams(cleanfile):
     cleanfile(tmp_log_filename)
     savereductionlog(
         tmp_log_filename,
-        detectordata={"slice_1": {"main_detector": {"iq": test_iq}}},
+        detectordata={"slice_1": {"main_detector": {"i1d": test_iq}}},
         python=pythonscript,
         starttime=starttime,
         pythonfile=pythonfile,
@@ -191,7 +191,7 @@ def test_writing_metadata(cleanfile):
     cleanfile(tmp_log_filename)
     savereductionlog(
         tmp_log_filename,
-        detectordata={"slice_1": {"main_detector": {"iq": test_iq}}},
+        detectordata={"slice_1": {"main_detector": {"i1d": test_iq}}},
         python=pythonscript,
         starttime=starttime,
         pythonfile=pythonfile,
@@ -223,7 +223,7 @@ def test_writing_iq_wedge_mode(cleanfile):
     test_iq = list([test_iq_1, test_iq_1])
     tmp_log_filename = _create_tmp_log_filename()
     cleanfile(tmp_log_filename)
-    savereductionlog(tmp_log_filename, detectordata={"slice_1": {"main_detector": {"iq": test_iq}}})
+    savereductionlog(tmp_log_filename, detectordata={"slice_1": {"main_detector": {"i1d": test_iq}}})
 
     assert os.path.exists(tmp_log_filename), "log file {} does not exist".format(tmp_log_filename)
 
@@ -249,7 +249,7 @@ def test_writing_iq_scalar_mode(cleanfile):
     test_iq = [_create_iq()]
     tmp_log_filename = _create_tmp_log_filename()
     cleanfile(tmp_log_filename)
-    savereductionlog(tmp_log_filename, detectordata={"slice_1": {"main_detector": {"iq": test_iq}}})
+    savereductionlog(tmp_log_filename, detectordata={"slice_1": {"main_detector": {"i1d": test_iq}}})
 
     assert os.path.exists(tmp_log_filename), "log file {} does not exist".format(tmp_log_filename)
 
@@ -276,7 +276,7 @@ def test_slicelogdata_is_a_dict(cleanfile):
     tmp_log_filename = _create_tmp_log_filename()
     cleanfile(tmp_log_filename)
     logslice_data_dict = "I'm a string"
-    detectordata = {"slice_1": {"main_detector": {"iq": test_iq}}}
+    detectordata = {"slice_1": {"main_detector": {"i1d": test_iq}}}
 
     with pytest.raises(RuntimeError):
         savereductionlog(tmp_log_filename, detectordata=detectordata, logslicedata=logslice_data_dict)
@@ -286,7 +286,7 @@ def test_not_using_slicelogdata_if_empty(cleanfile):
     test_iq = [_create_iq()]
     tmp_log_filename = _create_tmp_log_filename()
     cleanfile(tmp_log_filename)
-    detectordata = {"slice_1": {"main_detector": {"iq": test_iq}}}
+    detectordata = {"slice_1": {"main_detector": {"i1d": test_iq}}}
     logslice_data_dict = {}
 
     savereductionlog(tmp_log_filename, detectordata=detectordata, logslicedata=logslice_data_dict)
@@ -300,7 +300,7 @@ def test_slicelogdata_not_bigger_than_detectordata(cleanfile):
         "0": {"data": list([1, 2, 3]), "units": "m"},
         "1": {"data": list([1, 2, 3]), "units": "m"},
     }
-    detectordata = {"slice_1": {"main_detector": {"iq": test_iq}}}
+    detectordata = {"slice_1": {"main_detector": {"i1d": test_iq}}}
 
     with pytest.raises(ValueError):
         savereductionlog(tmp_log_filename, detectordata=detectordata, logslicedata=logslice_data_dict)
@@ -317,7 +317,7 @@ def test_writing_slicelogdata(cleanfile):
             "name": "my_slice_variable",
         }
     }
-    detectordata = {"slice_1": {"main_detector": {"iq": test_iq}}}
+    detectordata = {"slice_1": {"main_detector": {"i1d": test_iq}}}
     savereductionlog(tmp_log_filename, detectordata=detectordata, logslicedata=logslice_data_dict)
 
     assert os.path.exists(tmp_log_filename), "log file {} does not exist".format(tmp_log_filename)
@@ -372,7 +372,7 @@ def test_writing_iq_and_iqxqy_scalar_mode(cleanfile):
     cleanfile(tmp_log_filename)
     savereductionlog(
         tmp_log_filename,
-        detectordata={"slice_1": {"main_detector": {"iq": test_iq, "iqxqy": test_iqxqy}}},
+        detectordata={"slice_1": {"main_detector": {"i1d": test_iq, "iqxqy": test_iqxqy}}},
     )
 
     assert os.path.exists(tmp_log_filename), "log file {} does not exist".format(tmp_log_filename)
@@ -423,7 +423,7 @@ def test_writing_iq_and_iqxqy_wedge_mode(cleanfile):
     cleanfile(tmp_log_filename)
     savereductionlog(
         tmp_log_filename,
-        detectordata={"slice_1": {"main_detector": {"iq": test_iq, "iqxqy": test_iqxqy}}},
+        detectordata={"slice_1": {"main_detector": {"i1d": test_iq, "iqxqy": test_iqxqy}}},
     )
 
     assert os.path.exists(tmp_log_filename), "log file {} does not exist".format(tmp_log_filename)
@@ -514,7 +514,7 @@ def test_wrong_detectordata_format():
     with pytest.raises(RuntimeError):
         savereductionlog(
             "tmp_file_name",
-            detectordata={"main_detector": {"iq": [1, 2, 3], "iqxqy": [1, 3, 5]}},
+            detectordata={"main_detector": {"i1d": [1, 2, 3], "iqxqy": [1, 3, 5]}},
         )
 
 

--- a/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
+++ b/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
@@ -3,19 +3,19 @@ import pytest
 from drtsans.dataobjects import IQmod
 
 from drtsans.tof.eqsans.elastic_reference_normalization import (
-    determine_common_mod_q_range_mesh,
+    determine_common_domain_range_mesh,
     normalize_by_elastic_reference_1d,
 )
 from drtsans.tof.eqsans.elastic_reference_normalization import (
     calculate_scale_factor_mesh_grid,
 )
 from drtsans.tof.eqsans.elastic_reference_normalization import (
-    reshape_q_wavelength_matrix,
+    reshape_intensity_domain_meshgrid,
 )
 from drtsans.tof.eqsans.elastic_reference_normalization import (
-    determine_reference_wavelength_q1d_mesh,
+    determine_reference_wavelength_intensity_mesh,
 )
-from drtsans.tof.eqsans.elastic_reference_normalization import normalize_intensity_q1d
+from drtsans.tof.eqsans.elastic_reference_normalization import normalize_intensity_1d
 import numpy as np
 
 
@@ -26,7 +26,7 @@ def test_reshaped_imodq_2d():
     i_of_q = test_data[0]
 
     # Reshape
-    wl_vec, q_vec, i_array, error_array, dq_array = reshape_q_wavelength_matrix(i_of_q)
+    wl_vec, q_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(i_of_q)
 
     # Verify shape
     assert wl_vec.shape == (4,)
@@ -86,10 +86,10 @@ def test_determine_common_q_range():
     i_of_q = test_data[0]
 
     # Reshape
-    wl_vec, q_vec, i_array, error_array, dq_array = reshape_q_wavelength_matrix(i_of_q)
+    wl_vec, q_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(i_of_q)
 
     # Call the mesh-grid algorithm
-    qmin_index, qmax_index = determine_common_mod_q_range_mesh(q_vec, i_array)
+    qmin_index, qmax_index = determine_common_domain_range_mesh(q_vec, i_array)
 
     # Verify by comparing results from 2 algorithms
     assert q_vec[qmin_index] == 0.07
@@ -105,11 +105,11 @@ def test_determine_reference_wavelength():
     i_of_q = test_data[0]
 
     # Reshape
-    wl_vec, q_vec, i_array, error_array, dq_array = reshape_q_wavelength_matrix(i_of_q)
+    wl_vec, q_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(i_of_q)
 
     # Calculate reference wavelength and the related intensities and errors
-    ref_wl_intensities = determine_reference_wavelength_q1d_mesh(
-        wl_vec, q_vec, i_array, error_array, qmin_index=6, qmax_index=10
+    ref_wl_intensities = determine_reference_wavelength_intensity_mesh(
+        wl_vec, q_vec, i_array, error_array, xmin_index=6, xmax_index=10
     )
 
     # Verify
@@ -126,13 +126,15 @@ def test_calculate_scale_factor():
     # Get testing data and gold data
     test_i_of_q, gold_k_vec, gold_k_error_vec, gold_intensity_vec, gold_error_vec = create_testing_iq1d()
     # Reshape
-    wl_vec, q_vec, i_array, error_array, dq_array = reshape_q_wavelength_matrix(test_i_of_q)
+    wl_vec, q_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(test_i_of_q)
 
     # Calculate Qmin and Qmax
-    qmin_index, qmax_index = determine_common_mod_q_range_mesh(q_vec, i_array)
+    qmin_index, qmax_index = determine_common_domain_range_mesh(q_vec, i_array)
 
     # Calculate reference
-    ref_wl_ie = determine_reference_wavelength_q1d_mesh(wl_vec, q_vec, i_array, error_array, qmin_index, qmax_index)
+    ref_wl_ie = determine_reference_wavelength_intensity_mesh(
+        wl_vec, q_vec, i_array, error_array, qmin_index, qmax_index
+    )
 
     # Calculate scale factor
     k_vec, k_error_vec = calculate_scale_factor_mesh_grid(
@@ -185,13 +187,15 @@ def test_normalize_i_of_q1d():
     # Get testing data and gold data
     test_i_of_q, gold_k_vec, gold_k_error_vec, gold_intensity_vec, gold_error_vec = create_testing_iq1d()
     # Reshape
-    wl_vec, q_vec, i_array, error_array, dq_array = reshape_q_wavelength_matrix(test_i_of_q)
+    wl_vec, q_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(test_i_of_q)
 
     # Calculate Qmin and Qmax
-    qmin_index, qmax_index = determine_common_mod_q_range_mesh(q_vec, i_array)
+    qmin_index, qmax_index = determine_common_domain_range_mesh(q_vec, i_array)
 
     # Calculate reference
-    ref_wl_ie = determine_reference_wavelength_q1d_mesh(wl_vec, q_vec, i_array, error_array, qmin_index, qmax_index)
+    ref_wl_ie = determine_reference_wavelength_intensity_mesh(
+        wl_vec, q_vec, i_array, error_array, qmin_index, qmax_index
+    )
 
     # Calculate scale factor
     k_vec, k_error_vec = calculate_scale_factor_mesh_grid(
@@ -199,7 +203,7 @@ def test_normalize_i_of_q1d():
     )
 
     # Normalize
-    normalized = normalize_intensity_q1d(
+    normalized = normalize_intensity_1d(
         wl_vec,
         q_vec,
         i_array,


### PR DESCRIPTION
## Description of work:

The output of annular binning has been improved by changing the annotation from Q to phi for files, reduction logs, and plots. The plots produced from annular binning use a linear x axis (angle around the beam center), while the y axis can be logarithmic or linear.

Check all that apply:
- [x] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [x] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [ ] Added integration tests
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Story 364: [DRTSANS] Harmonizing the output style and content of 1D intensity profile obtained from annular binning](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=364)
- Links to related issues or pull requests:

## Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`