### PR TITLE
Add ability to use more than one wavelength bin for annular binning

### DIFF
--- a/src/drtsans/iq.py
+++ b/src/drtsans/iq.py
@@ -313,7 +313,7 @@ def bin_all(
             kwargs["q_min"] = qmin
         if qmax is not None:
             kwargs["q_max"] = qmax
-        binned_q1d_list.append(bin_annular_into_q1d(i_qxqy, bin_params, **kwargs))
+        binned_q1d_list.append(bin_annular_into_q1d(i_qxqy, bin_params, wavelength_bins=n_wavelength_bin, **kwargs))
     else:
         # regular binning including 'scalar' and 'wedge'
         if bin1d_type == "scalar":
@@ -601,7 +601,9 @@ def _toQmodAndAzimuthal(
     return data.intensity.ravel(), data.error.ravel(), q, dq, azimuthal
 
 
-def bin_annular_into_q1d(i_of_q, phi_bin_params, q_min=0.001, q_max=0.4, method=BinningMethod.NOWEIGHT):
+def bin_annular_into_q1d(
+    i_of_q, phi_bin_params, q_min=0.001, q_max=0.4, method=BinningMethod.NOWEIGHT, wavelength_bins: int | None = 1
+):
     """Annular 1D binning
 
     Calculates: I(azimuthal), sigma I and dazmuthal by assigning pixels to proper azimuthal angle bins
@@ -635,6 +637,8 @@ def bin_annular_into_q1d(i_of_q, phi_bin_params, q_min=0.001, q_max=0.4, method=
         , by default
     method : ~drtsans.BinningMethod
         binning method, no-weight or weighed
+    wavelength_bins: None, int
+        number of binned wavelength. If None, do not bin. If equal to 1, bin all wavelength together
 
     Returns
     -------
@@ -656,6 +660,11 @@ def bin_annular_into_q1d(i_of_q, phi_bin_params, q_min=0.001, q_max=0.4, method=
     # Filter by q_min and q_max
     allowed_q_index = np.logical_and((q_array > q_min), (q_array < q_max))
 
+    # Construct the wavelength array
+    wl_array = None
+    if i_of_q.wavelength is not None:
+        wl_array = i_of_q.wavelength[allowed_q_index]
+
     # select binning method
     # the methods call the independent axis "Q", but are generic to whatever values are passed in
     if method == BinningMethod.NOWEIGHT:
@@ -676,8 +685,8 @@ def bin_annular_into_q1d(i_of_q, phi_bin_params, q_min=0.001, q_max=0.4, method=
             intensity[allowed_q_index],
             error[allowed_q_index],
             phi_bins,
-            None,
-            1,
+            wl_array,
+            wavelength_bins,
         )
     else:
         binned_i_of_azimuthal = do_1d_binning(
@@ -686,8 +695,8 @@ def bin_annular_into_q1d(i_of_q, phi_bin_params, q_min=0.001, q_max=0.4, method=
             intensity[allowed_q_index],
             error[allowed_q_index],
             phi_bins,
-            None,
-            1,
+            wl_array,
+            wavelength_bins,
         )
 
     return binned_i_of_azimuthal

--- a/tests/unit/drtsans/test_i_of_q_annular_binning.py
+++ b/tests/unit/drtsans/test_i_of_q_annular_binning.py
@@ -3,7 +3,8 @@ import pytest
 
 from drtsans.dataobjects import IQazimuthal
 from drtsans.iq import BinningMethod, BinningParams, bin_annular_into_q1d
-from tests.unit.drtsans.i_of_q_binning_tests_data import generate_test_data
+from tests.unit.drtsans.i_of_q_binning_tests_data import generate_test_data, generate_test_data_wavelength
+
 
 # This module supports testing data for issue #246.
 # https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/issues/246
@@ -108,10 +109,90 @@ def test_1d_flat_data():
     # verify the results
     assert binned_iq.intensity.size == 18
     np.testing.assert_equal(binned_iq.intensity, 1.0)
-    # uncertainties are proportional to the number of input bins contributing to the annullar wedge
+    # uncertainties are proportional to the number of input bins contributing to the annular wedge
     np.testing.assert_allclose(binned_iq.error, 0.6, atol=0.11)
     # actually the azimuthal angle
     np.testing.assert_equal(binned_iq.mod_q, np.arange(10.0, 360.0, 20.0))
+
+
+def test_1d_flat_data_wl():
+    """Test annular binning with and without wavelength bins"""
+    # Q2D data for one wavelength
+    data2d = IQazimuthal(
+        intensity=np.full((21, 21), 1.0, dtype=float),
+        error=np.full((21, 21), 1.0, dtype=float),
+        qx=np.arange(-10, 11, 1, dtype=float),
+        qy=np.arange(-10, 11, 1, dtype=float),
+    )
+    data2d = data2d.ravel()
+
+    # repeat Q2D data 3 times for 3 wavelengths
+    wl_uniq = [1.5, 2.5, 3.5]
+    num_wl = len(wl_uniq)
+    data2d_wl = IQazimuthal(
+        intensity=np.tile(data2d.intensity, num_wl),
+        error=np.tile(data2d.error, num_wl),
+        qx=np.tile(data2d.qx, num_wl),
+        qy=np.tile(data2d.qy, num_wl),
+        wavelength=np.repeat(wl_uniq, len(data2d.intensity)),  # [1.5, 1.5, ..., 2.5, 2.5, ..., 3.5, 3.5, ...]
+    )
+
+    # perform the annular binning
+    phi_binning = BinningParams(0, 360, 18)  # 20 deg bins
+    binned_i1d_wl = bin_annular_into_q1d(
+        data2d_wl, phi_binning, q_min=9.0, q_max=10.0, method=BinningMethod.NOWEIGHT, wavelength_bins=None
+    )
+    binned_i1d_no_wl = bin_annular_into_q1d(
+        data2d_wl, phi_binning, q_min=9.0, q_max=10.0, method=BinningMethod.NOWEIGHT
+    )
+
+    # verify the results
+    assert binned_i1d_wl.intensity.shape[0] == phi_binning.bins * num_wl
+    assert binned_i1d_no_wl.intensity.shape[0] == phi_binning.bins
+    # intensity
+    np.testing.assert_equal(binned_i1d_wl.intensity, 1.0)
+    np.testing.assert_equal(binned_i1d_no_wl.intensity, 1.0)
+    # uncertainties are inversely proportional to the number of input bins contributing to the annular wedge
+    np.testing.assert_allclose(binned_i1d_wl.error, 0.6, atol=0.11)
+    np.testing.assert_allclose(binned_i1d_no_wl.error, 0.4, atol=0.12)
+    # actually the azimuthal angle
+    np.testing.assert_equal(binned_i1d_wl.mod_q, np.tile(np.arange(10.0, 360.0, 20.0), num_wl))
+
+
+def test_1d_wavelength():
+    # Define input Q2D data
+    num_wl = 3
+    intensities, sigmas, qx_array, dqx_array, qy_array, dqy_array, wl_array = generate_test_data_wavelength(2, num_wl)
+    data2d = IQazimuthal(
+        intensity=intensities,
+        error=sigmas,
+        qx=qx_array,
+        qy=qy_array,
+        delta_qx=dqx_array,
+        delta_qy=dqy_array,
+        wavelength=wl_array,
+    )
+
+    # perform the annular binning
+    phi_binning = BinningParams(0, 360, 18)  # 20 deg bins
+    binned_i1d_wl = bin_annular_into_q1d(data2d, phi_binning, method=BinningMethod.NOWEIGHT, wavelength_bins=None)
+
+    # verify the results
+    assert binned_i1d_wl.intensity.shape[0] == phi_binning.bins * num_wl
+    # intensity
+    assert np.nanmin(binned_i1d_wl.intensity) == pytest.approx(39.333, rel=1e-4)
+    assert np.nanmax(binned_i1d_wl.intensity) == pytest.approx(77.0, rel=1e-4)
+    # error
+    assert np.nanmin(binned_i1d_wl.error) == pytest.approx(2.9155, rel=1e-4)
+    assert np.nanmax(binned_i1d_wl.error) == pytest.approx(5.0662, rel=1e-4)
+    # actually the azimuthal angle
+    np.testing.assert_equal(binned_i1d_wl.mod_q, np.tile(np.arange(10.0, 360.0, 20.0), num_wl))
+
+    # verify one bin
+    assert binned_i1d_wl.mod_q[3] == pytest.approx(70.0, rel=1e-4)
+    assert binned_i1d_wl.intensity[3] == pytest.approx(59.0, rel=1e-4)
+    assert binned_i1d_wl.error[3] == pytest.approx(4.4347, rel=1e-4)
+    assert binned_i1d_wl.wavelength[3] == pytest.approx(1.5, rel=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
