### PR TITLE
Non-Integer TimeSlice Defect

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -26,7 +26,7 @@ Release Notes
 - PR #1015: Upgrades to Mantid 6.12 and numpy 2
 
 **Of interest to the Developer:**
-
+- PR #1019: Fixes an edge case bug in creating the sample logs periodic index log where the number of entries is less than the number of times
 
 1.13.0
 ------

--- a/src/drtsans/samplelogs.py
+++ b/src/drtsans/samplelogs.py
@@ -135,6 +135,7 @@ def periodic_index_log(
 
     # generate period/interval blocks
     # this creates intervals per period, of the range [period start, period end)
+    # where `period end` may be truncated due to the duration being reached
     # ``- 1e-15`` makes the end range exclusive for integers
     times = [
         np.arange(period * i + offset, min(duration, period * (i + 1) + offset - 1e-15), interval)
@@ -145,10 +146,11 @@ def periodic_index_log(
     # array of values in each period, scaled by the step
     values_in_period = step * np.arange(0, np.ceil(period / interval))
 
-    # repeat the values in a period up to the number of periods,
-    # plus one
+    # repeat the values for all slices
+    # plus 1 because there may be a remainder, so this guarantees the tiling is large enough
+    #  to cover all slices
     # then truncate to the length of times, then cast to list
-    entries = np.tile(values_in_period, period_count + interval_count)[: len(times)].tolist()
+    entries = np.tile(values_in_period, period_count * (interval_count + 1))[: len(times)].tolist()
 
     assert len(times) == len(entries), (
         f"times and entries must have the same length: len(times) {len(times)} != len(entries) {len(entries)}"

--- a/tests/unit/drtsans/test_samplelogs.py
+++ b/tests/unit/drtsans/test_samplelogs.py
@@ -67,6 +67,8 @@ def test_periodic_index_log():
         (30, 40, 60, 0, 1, 3),
         # offset tests
         (60, 60, 60, 1, 1, 1),
+        # edge case where entries must overtile, or there won't be enough to match times
+        (0.31416253927, 3.1416253927, 11063.2470703125, 1.19011221899, 1, 38639),
     ],
     ids=[
         # integer number of intervals in period
@@ -94,6 +96,7 @@ def test_periodic_index_log():
         "i!|p!|d",
         "i|d",
         "offset-duration",
+        "require-overtiling",
     ],
 )
 def test_periodic_index_log_cases(interval, period, duration, offset, step, expected):


### PR DESCRIPTION
## Description of work:

Previous work (see references) had enabled flexible time slices, where the timeslice could be a non-integer multiple of timeperiod. This updated the generation of the time series property used to index the sample logs.

An edge case in generating the time series property was found when conditions were such that `len(entries) < len(times)`. This was found to be due to under-generating the number of values in the tiling. Simply guaranteeing the are ample entries and truncating to `len(times)` is sufficient and what was done previously.

Check all that apply:
- [X] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [X] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [10287: [drtsans] Assertion on incomplete last period in time slicing](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/10287)
- Links to related issues or pull requests:
Original item:
[8995: [DRTSANS] Flexible Time Slicing: Supporting Non-Integer Period Divisions](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8995)
https://github.com/neutrons/drtsans/pull/999

## Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [x] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [x] best software practices
    + [x] clearly named variables (better to be verbose in variable names)
    + [x] code comments explaining the intent of code blocks
- [x] All the tests are passing
- [x] The documentation is up to date
- [x] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
