### PR TITLE
Simplify error calculation for 2D incoherent inelastic correction

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -26,6 +26,7 @@ Release Notes
 
   **Of interest to the User**:
   - PR #1025: Includes v1.14.0 release notes.
+  - PR #1029: Calculation of the I(Q2D) error is simplified for the incoherent inelastic correction
 
   **Of interest to the Developer:**
   - PR #???:

--- a/src/drtsans/tof/eqsans/incoherence_correction_1d.py
+++ b/src/drtsans/tof/eqsans/incoherence_correction_1d.py
@@ -120,7 +120,7 @@ def correct_incoherence_inelastic_all(
 
     # Correct 2D
     if i_of_q_2d:
-        corrected_2d = correct_incoherence_inelastic_2d(i_of_q_2d, b_array, ref_wl_index)
+        corrected_2d = correct_incoherence_inelastic_2d(i_of_q_2d, b_array)
     else:
         corrected_2d = None
 

--- a/src/drtsans/tof/eqsans/incoherence_correction_2d.py
+++ b/src/drtsans/tof/eqsans/incoherence_correction_2d.py
@@ -49,96 +49,15 @@ def reshape_q_azimuthal(i_of_q):
     )
 
 
-def gen_q_subset_mask(i_of_q, qx_len, qy_len, wavelength_len):
-    """Generate filtering array for q_subset from intensity vector for 2d case
-
-    Calculation of B requires usage of only qx, qy where all lambda exist,
-    so this function handles creating a boolean array for filtering. Said
-    array can be described by Q_valid(Qx, Qy) flattened to a 1D array of
-    length qx_len*qy_len
-
-    Parameters
-    ----------
-    i_of_q: ~drtsans.dataobjects.IQazimuthal
-        Input reshaped I(Qx, Qy, wavelength)
-    qx_len: int
-        Number of unique Qx values
-    qy_len: int
-        Number of unique Qy values
-    wavelength_len: int
-        Number of unique wavelength values
-
-    Returns
-    -------
-    ~numpy.ndarray
-        1D boolean numpy array representing q_subset in form Qxy, wavelength
-
-    """
-    _q_by_wavelength = i_of_q.intensity.reshape((qx_len * qy_len, wavelength_len))
-    _mask_squeezed = np.all(np.isfinite(_q_by_wavelength), 1)
-    return _mask_squeezed
-
-
-def intensity_error(i_of_q, q_subset_mask, qx_len, qy_len, wavelength_len, ref, b_error):
-    """Calculates corrected error from reshaped i_of_q and b error vector
-
-    Calculation of error for q_subset is described by
-    (dF_{x,y}^{lambda_i})^2 = (1-2/N_q)(dI_{x,y}^{lambda_i})^2 + (dB^{lambda_i})^2
-    Calculation of error for q not in q_subset is described by
-    (dF_{x,y}^{lambda_i})^2 = (dI_{x,y}^{lambda_i})^2 + (dB^{lambda_i})^2
-    Calculation is described in greater detail
-    https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/issues/689
-
-    Parameters
-    ----------
-    i_of_q: ~drtsans.dataobjects.IQazimuthal
-        Input reshaped I(Qx, Qy, wavelength)
-    q_subset_mask: ~numpy.ndarray
-        Boolean array defining q_subset
-    qx_len: int
-        Number of unique Qx values
-    qy_len: int
-        Number of unique Qy values
-    wavelength_len: int
-        Number of unique wavelength values
-    ref: int
-        Index of reference wavelength
-    b_error: ~numpy.ndarray
-        Error in b factor
-
-    Returns
-    -------
-    ~numpy.ndarray
-        intensity error vector
-
-    """
-    # collapse error and mask to 3D numpy arrays
-    _i_e_pack = i_of_q.error.copy().reshape((qx_len, qy_len, wavelength_len))
-    _mask_pack = q_subset_mask.repeat(wavelength_len).reshape((qx_len, qy_len, wavelength_len))
-    _num_q_subset = q_subset_mask.sum()
-    _c_val = 1 - 2 / _num_q_subset
-    # step through each wavelength
-    for _wave in range(wavelength_len):
-        # no correction for reference wavelength
-        if _wave == ref:
-            continue
-        # grab slice of filter and calculate sum of filtered values
-        _w_mask = _mask_pack[:, :, _wave]
-        # apply error correction to q_subset
-        _i_e_pack[_w_mask, _wave] = _c_val * _i_e_pack[_w_mask, _wave] ** 2 + b_error[_wave] ** 2
-        # apply error correction to not q_subset
-        _i_e_pack[~_w_mask, _wave] = _i_e_pack[~_w_mask, _wave] ** 2 + b_error[_wave] ** 2
-        # final sqrt to finish correction
-        _i_e_pack[:, :, _wave] = np.sqrt(_i_e_pack[:, :, _wave])
-    # return flattened for consistency
-    return _i_e_pack.flatten()
-
-
-def correct_incoherence_inelastic_2d(i_of_q, b_array, ref_wl_index):
+def correct_incoherence_inelastic_2d(i_of_q, b_array):
     """Correct I(Q2D) with wavelength dependent incoherence inelastic scattering
 
     This method implements the workflow for correcting I(Q2D) with
     wavelength-dependent incoherent inelastic scattering
+
+    The correction of I(Q2D) uses the correction term b calculated from the 1D I(Q, lambda), since
+    this gives a lower statistical error in b. The error in the corrected I(Q2D) is calculated
+    assuming b is independent of I(Q2D).
 
     Parameters
     ----------
@@ -146,13 +65,11 @@ def correct_incoherence_inelastic_2d(i_of_q, b_array, ref_wl_index):
         I(Qx, Qy, wavelength) with error
     b_array: ~numpy.ndarray
         2D numpy array for B[wavelength], B error[wavelength]
-    ref_wl_index: int
-        Index of reference wavelength in the wavelength vector
 
     Returns
     -------
     CorrectedIQ2D
-        named tuple of corrected I(Qx, Qy, wavelength), b2d, b2d error
+        named tuple of corrected I(Qx, Qy, wavelength), b1d, b1d error
 
     """
     # coerce IQazimuthal data to desired shapes
@@ -161,16 +78,12 @@ def correct_incoherence_inelastic_2d(i_of_q, b_array, ref_wl_index):
     # grab unique lengths
     _qx_len = np.unique(_i_of_q.qx).shape[0]
     _qy_len = np.unique(_i_of_q.qy).shape[0]
-    _wavelength_len = np.unique(_i_of_q.wavelength).shape[0]
-
-    # create mask for q_subset
-    q_subset = gen_q_subset_mask(_i_of_q, _qx_len, _qy_len, _wavelength_len)
 
     # get b values
-    b2d, b2d_error = b_array
+    b1d, b1d_error = b_array
 
-    corrected_intensity = _i_of_q.intensity - np.tile(b2d, _qx_len * _qy_len)
-    corrected_error = intensity_error(_i_of_q, q_subset, _qx_len, _qy_len, _wavelength_len, ref_wl_index, b2d_error)
+    corrected_intensity = _i_of_q.intensity - np.tile(b1d, _qx_len * _qy_len)
+    corrected_error = np.sqrt(_i_of_q.error**2 + np.tile(b1d_error**2, _qx_len * _qy_len))
     corrected_i_of_q = IQazimuthal(
         intensity=corrected_intensity,
         error=corrected_error,
@@ -180,5 +93,5 @@ def correct_incoherence_inelastic_2d(i_of_q, b_array, ref_wl_index):
         delta_qx=_i_of_q.delta_qx,
         delta_qy=_i_of_q.delta_qy,
     )
-    corrected = CorrectedIQ2D(iq2d=corrected_i_of_q, b_factor=b2d, b_error=b2d_error)
+    corrected = CorrectedIQ2D(iq2d=corrected_i_of_q, b_factor=b1d, b_error=b1d_error)
     return corrected


### PR DESCRIPTION
## Description of work:

Based on discussions with the instrument scientists (IS), the 2D incoherent inelastic error calculation can be simplified by making the approximation that the 1D correction term `b` is independent of I(Q2D) when calculating the corrected error in I(Q2D).

Check all that apply:
- [x] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] ~~updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)~~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Story 10157: [drtsans] Add user documentation for elastic reference normalization and inelastic incoherent correction](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10157)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
