### PR TITLE
Ewm10804 new option select reference detector

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,7 +23,7 @@ Release Notes
   XXXX-XX-XX
 
   **Of interest to the User**:
-  - PR #XYZ: one-liner description
+  - PR #1034: Now able to select reference detector for stitching
 
   **Of interest to the Developer:**
   - PR #XYZ: one-liner description

--- a/src/drtsans/configuration/schema/BIOSANS.json
+++ b/src/drtsans/configuration/schema/BIOSANS.json
@@ -182,6 +182,7 @@
         "overlapStitchReferenceDetector": {
           "type": "string",
           "description": "If provided, this will be the reference detector used for stitching. Must be one of ['main', 'midrange', 'wing']",
+	  "enum": ["main", "midrange", "wing"],
           "default": "main"
         },
 

--- a/src/drtsans/configuration/schema/BIOSANS.json
+++ b/src/drtsans/configuration/schema/BIOSANS.json
@@ -179,6 +179,11 @@
           "$ref":  "common.json#/definitions/safeStitchQboundsSpecs",
           "description": "The maximum |Q| value in the region(s) where intensities for detectors overlap. Allowed overlaps are main with wing, main with midrange, and midrange with wing detector."
         },
+        "overlapStitchReferenceDetector": {
+          "type": "string",
+          "description": "If provided, this will be the reference detector used for stitching. Must be one of ['main', 'midrange', 'wing']",
+          "default": "main"
+        },
 
         "wedge1QminMain": {
           "$ref":  "common.json#/definitions/safeStringPositiveFloat",

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -591,7 +591,7 @@ def check_overlap_stitch_configuration(reduction_input: dict) -> None:
     if (reduction_config["overlapStitchReferenceDetector"] == "midrange") and (
         reduction_input["has_midrange_detector"] is False
     ):
-        raise ValueError("Midrange detector cannot be reference for stitching")
+        raise ValueError("'overlapStitchReferenceDetector: midrange' is invalid for this configuration")
 
     if reduction_input["has_midrange_detector"] and not reduction_config["overlapStitchIgnoreMidrange"]:
         num_params_overlap_stitch = 2

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -1418,7 +1418,7 @@ def reduce_single_configuration(
     processed_data_main_use = None
     trans_main_use = None
 
-    processed_data_wedge_use = None
+    processed_data_wing_use = None
     trans_wing_use = None
 
     processed_data_midrange_use = None

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -586,18 +586,15 @@ def check_overlap_stitch_configuration(reduction_input: dict) -> None:
     """
     reduction_config = reduction_input["configuration"]
     num_params_overlap_stitch = 1
+
+    # midrange detector cannot be used for reference if it's not used
+    if (reduction_config["overlapStitchReferenceDetector"] == "midrange") and (
+        reduction_input["has_midrange_detector"] is False
+    ):
+        raise ValueError("Midrange detector cannot be reference for stitching")
+
     if reduction_input["has_midrange_detector"] and not reduction_config["overlapStitchIgnoreMidrange"]:
         num_params_overlap_stitch = 2
-        if reduction_config["overlapStitchReferenceDetector"] not in ["main", "midrange", "wing"]:
-            raise ValueError(
-                f"Configuration 'overlapStitchReferenceDetector': {reduction_config['overlapStitchReferenceDetector']}"
-                " is invalid for this configuration"
-            )
-    elif reduction_config["overlapStitchReferenceDetector"] not in ["main", "wing"]:
-        raise ValueError(
-            f"Configuration 'overlapStitchReferenceDetector': {reduction_config['overlapStitchReferenceDetector']}"
-            " is invalid for this configuration"
-        )
 
     params_overlap_stitch = ["overlapStitchQmin", "overlapStitchQmax"]
     if reduction_config["1DQbinType"] == "wedge":

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -568,10 +568,10 @@ def check_overlap_stitch_configuration(reduction_input: dict) -> None:
 
     If the midrange detector is absent,
         1) there are two detectors and one overlap region, i.e. one Qmin/Qmax.
-        2) overlapStitchQmax must be one of ["main", "wing"]
+        2) overlapStitchReferenceDetector must be one of ["main", "wing"]
     If the midrange detector is present,
         1) there are three detectors and two overlap regions, i.e. two Qmin/Qmax.
-        2) overlapStitchQmax must be one of ["main", "midrange", "wing"]
+        2) overlapStitchReferenceDetector must be one of ["main", "midrange", "wing"]
     Parameters
     ----------
     reduction_input

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -568,10 +568,10 @@ def check_overlap_stitch_configuration(reduction_input: dict) -> None:
 
     If the midrange detector is absent,
         1) there are two detectors and one overlap region, i.e. one Qmin/Qmax.
-        2) overlapStitchQmax must be one of ["main", "wedge"]
+        2) overlapStitchQmax must be one of ["main", "wing"]
     If the midrange detector is present,
         1) there are three detectors and two overlap regions, i.e. two Qmin/Qmax.
-        2) overlapStitchQmax must be one of ["main", "midrange", "wedge"]
+        2) overlapStitchQmax must be one of ["main", "midrange", "wing"]
     Parameters
     ----------
     reduction_input
@@ -588,15 +588,15 @@ def check_overlap_stitch_configuration(reduction_input: dict) -> None:
     num_params_overlap_stitch = 1
     if reduction_input["has_midrange_detector"] and not reduction_config["overlapStitchIgnoreMidrange"]:
         num_params_overlap_stitch = 2
-        if reduction_config["overlapStitchReferenceDetector"] not in ["main", "midrange", "wedge"]:
+        if reduction_config["overlapStitchReferenceDetector"] not in ["main", "midrange", "wing"]:
             raise ValueError(
-                f"Stitch reference detector {reduction_config['overlapStitchReferenceDetector']}"
-                "is invalid for this configuration"
+                f"Configuration 'overlapStitchReferenceDetector': {reduction_config['overlapStitchReferenceDetector']}"
+                " is invalid for this configuration"
             )
-    elif reduction_config["overlapStitchReferenceDetector"] not in ["main", "wedge"]:
+    elif reduction_config["overlapStitchReferenceDetector"] not in ["main", "wing"]:
         raise ValueError(
-            f"Stitch reference detector {reduction_config['overlapStitchReferenceDetector']}"
-            "is invalid for this configuration"
+            f"Configuration 'overlapStitchReferenceDetector': {reduction_config['overlapStitchReferenceDetector']}"
+            " is invalid for this configuration"
         )
 
     params_overlap_stitch = ["overlapStitchQmin", "overlapStitchQmax"]

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -590,11 +590,13 @@ def check_overlap_stitch_configuration(reduction_input: dict) -> None:
         num_params_overlap_stitch = 2
         if reduction_config["overlapStitchReferenceDetector"] not in ["main", "midrange", "wedge"]:
             raise ValueError(
-                f"Stitch reference detector {reduction_config['overlapStitchReferenceDetector']} is invalid for this configuration"
+                f"Stitch reference detector {reduction_config['overlapStitchReferenceDetector']}"
+                "is invalid for this configuration"
             )
     elif reduction_config["overlapStitchReferenceDetector"] not in ["main", "wedge"]:
         raise ValueError(
-            f"Stitch reference detector {reduction_config['overlapStitchReferenceDetector']} is invalid for this configuration"
+            f"Stitch reference detector {reduction_config['overlapStitchReferenceDetector']}"
+            "is invalid for this configuration"
         )
 
     params_overlap_stitch = ["overlapStitchQmin", "overlapStitchQmax"]
@@ -1415,15 +1417,6 @@ def reduce_single_configuration(
     output = []
     detectordata = {}
 
-    processed_data_main_use = None
-    trans_main_use = None
-
-    processed_data_wing_use = None
-    trans_wing_use = None
-
-    processed_data_midrange_use = None
-    trans_midrange_use = None
-
     for i, raw_sample_ws in enumerate(loaded_ws.sample):
         sample_name = "_slice_{}".format(i + 1)
         if len(loaded_ws.sample) > 1:
@@ -1465,10 +1458,6 @@ def reduce_single_configuration(
                 absolute_scale=absolute_scale,
                 keep_processed_workspaces=False,
             )
-            if not processed_data_main_use:
-                processed_data_main_use = processed_data_main
-                trans_main_use = trans_main
-
             processed_data_wing, trans_wing = process_single_configuration(
                 raw_sample_ws,
                 sample_trans_ws=sample_trans_ws,
@@ -1497,9 +1486,6 @@ def reduce_single_configuration(
                 absolute_scale=absolute_scale,
                 keep_processed_workspaces=False,
             )
-            if not processed_data_wing_use:
-                processed_data_wing_use = processed_data_wing
-                trans_wing_use = trans_wing
 
             if reduction_config["has_midrange_detector"]:
                 processed_data_midrange, trans_midrange = process_single_configuration(
@@ -1530,10 +1516,6 @@ def reduce_single_configuration(
                     absolute_scale=absolute_scale,
                     keep_processed_workspaces=False,
                 )
-
-                if not processed_data_midrange_use:
-                    processed_data_midrange_use = processed_data_midrange
-                    trans_midrange_use = trans_midrange
 
             else:
                 processed_data_midrange, trans_midrange = (
@@ -1743,7 +1725,7 @@ def reduce_single_configuration(
         )
 
     try:
-        processed_data_main_use
+        processed_data_main
     except NameError:
         raise NoDataProcessedError
 
@@ -1760,23 +1742,23 @@ def reduce_single_configuration(
         "beam_center": {"x": xc, "y": yc, "y_midrange": ym, "y_wing": yw},
         "fit results": fit_results,
         "sample_transmission": {
-            "main": trans_main_use["sample"],
-            "midrange": trans_midrange_use["sample"],
-            "wing": trans_wing_use["sample"],
+            "main": trans_main["sample"],
+            "midrange": trans_midrange["sample"],
+            "wing": trans_wing["sample"],
         },
         "background_transmission": {
-            "main": trans_main_use["background"],
-            "midrange": trans_midrange_use["background"],
-            "wing": trans_wing_use["background"],
+            "main": trans_main["background"],
+            "midrange": trans_midrange["background"],
+            "wing": trans_wing["background"],
         },
     }
 
     samplelogs = {
-        "main": SampleLogs(processed_data_main_use),
-        "wing": SampleLogs(processed_data_wing_use),
+        "main": SampleLogs(processed_data_main),
+        "wing": SampleLogs(processed_data_wing),
     }
     if reduction_config["has_midrange_detector"]:
-        samplelogs["midrange"] = SampleLogs(processed_data_midrange_use)
+        samplelogs["midrange"] = SampleLogs(processed_data_midrange)
     logslice_data_dict = reduction_input["logslice_data"]
 
     savereductionlog(

--- a/src/drtsans/stitch.py
+++ b/src/drtsans/stitch.py
@@ -202,6 +202,47 @@ def get_stitch_boundaries(reduction_config, iq1d_unbinned, anisotropic=False):
     return bounds
 
 
+def get_target_profile_index(iq1d_binned, reduction_config):
+    """Get the target profile index using the binned IQ1D data and reduction configuration.
+
+    The reduction configuration field ``overlapStitchReferenceDetector`` defines the name of the detector to use.
+    The size of ``iq1d_binned`` determines the ordering of the data, and hence can be used to return the index.
+    If ``len(iq1d_binned)`` == 2, its order is [main, wing]
+    If ``len(iq1d_binned)`` == 3, its order is [main, midrange, wing]
+
+    Parameters
+    ----------
+    iq1d_binned: list of lists of ~drtsans.dataobjects.IQmod
+        A list of lists of ~drtsans.dataobjects.IQmod objects. The outer list is the list of detectors ordered by
+        increasing Q-values. The inner lists are for different binnings of the original data from the detector.
+        Example: [[IQ_main_wedge1, IQ_main_wedge2], [IQ_wing_wedge1, IQ_wing_wedge2]]
+    reduction_config: dict
+        The dictionary of reduction parameters.
+
+    Returns
+    -------
+    int
+        The index of the target profile
+    """
+    detector_index_map = {
+        2: {
+            "main": 0,
+            "wing": 1,
+        },
+        3: {
+            "main": 0,
+            "midrange": 1,
+            "wing": 2,
+        },
+    }
+
+    try:
+        detector_key = reduction_config["overlapStitchReferenceDetector"]
+        return detector_index_map[len(iq1d_binned)][detector_key]
+    except KeyError:
+        raise ValueError("'midrange' is an invalid reference detector for this configuration")
+
+
 def stitch_binned_profiles(iq1d_unbinned, iq1d_binned, reduction_config):
     """Stitch together sequences of intensity profiles from different detector panels (main, wing and midrange),
     that cover a different range of Q-values, returning a single encompassing profile per sequence.
@@ -242,6 +283,7 @@ def stitch_binned_profiles(iq1d_unbinned, iq1d_binned, reduction_config):
         return iq1d_combined_out
 
     boundaries = get_stitch_boundaries(reduction_config, iq1d_unbinned, anisotropic=len(iq1d_binned[0]) > 1)
+    target_profile_index = get_target_profile_index(iq1d_binned, reduction_config)
 
     iq1d_binned_main = iq1d_binned[0]
     for ibinning in range(len(iq1d_binned_main)):
@@ -252,7 +294,7 @@ def stitch_binned_profiles(iq1d_unbinned, iq1d_binned, reduction_config):
             iq1d_combined = stitch_profiles(
                 profiles=profiles,
                 overlaps=overlaps,
-                target_profile_index=0,
+                target_profile_index=target_profile_index,
             )
         except ValueError:
             iq1d_combined = IQmod(intensity=[], error=[], mod_q=[], delta_mod_q=[])

--- a/src/drtsans/stitch.py
+++ b/src/drtsans/stitch.py
@@ -280,7 +280,6 @@ def stitch_binned_profiles(iq1d_unbinned, iq1d_binned, reduction_config):
         return iq1d_combined_out
 
     boundaries = get_stitch_boundaries(reduction_config, iq1d_unbinned, anisotropic=len(iq1d_binned[0]) > 1)
-    target_profile_index = get_target_profile_index(iq1d_binned, reduction_config)
 
     iq1d_binned_main = iq1d_binned[0]
     for ibinning in range(len(iq1d_binned_main)):
@@ -291,7 +290,7 @@ def stitch_binned_profiles(iq1d_unbinned, iq1d_binned, reduction_config):
             iq1d_combined = stitch_profiles(
                 profiles=profiles,
                 overlaps=overlaps,
-                target_profile_index=target_profile_index,
+                target_profile_index=get_target_profile_index(iq1d_binned, reduction_config),
             )
         except ValueError:
             iq1d_combined = IQmod(intensity=[], error=[], mod_q=[], delta_mod_q=[])

--- a/src/drtsans/stitch.py
+++ b/src/drtsans/stitch.py
@@ -236,11 +236,8 @@ def get_target_profile_index(iq1d_binned, reduction_config):
         },
     }
 
-    try:
-        detector_key = reduction_config["overlapStitchReferenceDetector"]
-        return detector_index_map[len(iq1d_binned)][detector_key]
-    except KeyError:
-        raise ValueError("'midrange' is an invalid reference detector for this configuration")
+    detector_key = reduction_config["overlapStitchReferenceDetector"]
+    return detector_index_map[len(iq1d_binned)][detector_key]
 
 
 def stitch_binned_profiles(iq1d_unbinned, iq1d_binned, reduction_config):

--- a/tests/integration/drtsans/test_stitch.py
+++ b/tests/integration/drtsans/test_stitch.py
@@ -456,10 +456,7 @@ def test_stitch_binned_profiles_isotropic(data_test_16b):
     data = data_test_16b  # handy shortcut
     qmin = [x[0] for x in data.overlaps]
     qmax = [x[1] for x in data.overlaps]
-    reduction_config = {
-        "overlapStitchQmin": qmin,
-        "overlapStitchQmax": qmax,
-    }
+    reduction_config = {"overlapStitchQmin": qmin, "overlapStitchQmax": qmax, "overlapStitchReferenceDetector": "main"}
     iq1d_unbinned = data.profiles
     # simulate isotropic binning: list of 1 profile per detector
     iq1d_binned = [[profile] for profile in data.profiles]
@@ -476,6 +473,7 @@ def test_stitch_binned_profiles_wedges(data_test_16b):
         "wedge1overlapStitchQmax": qmax,
         "wedge2overlapStitchQmin": qmin,
         "wedge2overlapStitchQmax": qmax,
+        "overlapStitchReferenceDetector": "main",
     }
     iq1d_unbinned = data.profiles
     # simulate anisotropic binning: list of 2 profiles per detector (2 wedges)

--- a/tests/unit/drtsans/mono/biosans/test_api.py
+++ b/tests/unit/drtsans/mono/biosans/test_api.py
@@ -801,7 +801,6 @@ def test_plot_reduction_output(monkeypatch):
             [0.015, 0.025],
         ),  # too many Qmin/Qmax for run without midrange detector
         (True, False, False, "main", [0.01, 0.02, 0.03], [0.015, 0.025, 0.035]),  # lists too long
-        (True, False, False, "invalid", None, None),  # reference detector is invalid
         (True, False, False, "midrange", None, None),  # midrange selected but not run with
         # valid inputs:
         (False, False, False, "main", None, None),

--- a/tests/unit/drtsans/mono/biosans/test_api.py
+++ b/tests/unit/drtsans/mono/biosans/test_api.py
@@ -781,29 +781,57 @@ def test_plot_reduction_output(monkeypatch):
     ],
 )
 @pytest.mark.parametrize(
-    "throws_error, has_midrange, ignore_midrange, qmin_value, qmax_value",
+    "throws_error, has_midrange, ignore_midrange, reference_detector, qmin_value, qmax_value",
     [
-        (True, True, False, [0.01], [0.015]),  # too few Qmin/Qmax for run with midrange detector
-        (True, True, True, [0.01, 0.02], [0.015, 0.025]),  # too many Qmin/Qmax for overlapStitchIgnoreMidrange = True
-        (True, False, False, [0.01, 0.02], [0.015, 0.025]),  # too many Qmin/Qmax for run without midrange detector
-        (True, False, False, [0.01, 0.02, 0.03], [0.015, 0.025, 0.035]),  # lists too long
+        (True, True, False, "main", [0.01], [0.015]),  # too few Qmin/Qmax for run with midrange detector
+        (
+            True,
+            True,
+            True,
+            "main",
+            [0.01, 0.02],
+            [0.015, 0.025],
+        ),  # too many Qmin/Qmax for overlapStitchIgnoreMidrange = True
+        (
+            True,
+            False,
+            False,
+            "main",
+            [0.01, 0.02],
+            [0.015, 0.025],
+        ),  # too many Qmin/Qmax for run without midrange detector
+        (True, False, False, "main", [0.01, 0.02, 0.03], [0.015, 0.025, 0.035]),  # lists too long
+        (True, False, False, "invalid", None, None),  # reference detector is invalid
+        (True, False, False, "midrange", None, None),  # midrange selected but not run with
         # valid inputs:
-        (False, False, False, None, None),
-        (False, True, False, None, None),
-        (False, False, False, [], []),
-        (False, True, False, [], []),
-        (False, False, False, [0.01], [0.015]),  # run without midrange detector
-        (False, True, False, [0.01, 0.02], [0.015, 0.025]),  # run with midrange detector
-        (False, True, True, [0.01], [0.015]),  # run with midrange detector, but it is excluded from stitching
+        (False, False, False, "main", None, None),
+        (False, False, False, "wing", None, None),
+        (False, True, False, "main", None, None),
+        (False, False, False, "main", [], []),
+        (False, True, False, "midrange", None, None),
+        (False, True, False, "main", [], []),
+        (False, False, False, "main", [0.01], [0.015]),  # run without midrange detector
+        (False, True, False, "main", [0.01, 0.02], [0.015, 0.025]),  # run with midrange detector
+        (False, True, True, "main", [0.01], [0.015]),  # run with midrange detector, but it is excluded from stitching
     ],
 )
 def test_check_overlap_stitch_configuration(
-    qbintype1d, qmin_name, qmax_name, throws_error, has_midrange, ignore_midrange, qmin_value, qmax_value
+    qbintype1d,
+    qmin_name,
+    qmax_name,
+    throws_error,
+    has_midrange,
+    ignore_midrange,
+    reference_detector,
+    qmin_value,
+    qmax_value,
 ):
     """Unit test for helper function check_overlap_stitch_configuration."""
     reduction_config = {}
     reduction_config["1DQbinType"] = qbintype1d
     reduction_config["overlapStitchIgnoreMidrange"] = ignore_midrange
+    reduction_config["overlapStitchReferenceDetector"] = reference_detector
+
     # first, set all overlap stitch parameters to None to only test the ones given by qmin_name and qmax_name
     reduction_config["overlapStitchQmin"] = None
     reduction_config["overlapStitchQmax"] = None
@@ -811,6 +839,7 @@ def test_check_overlap_stitch_configuration(
     reduction_config["wedge1overlapStitchQmax"] = None
     reduction_config["wedge2overlapStitchQmin"] = None
     reduction_config["wedge2overlapStitchQmax"] = None
+
     # set the overlap stitch parameters given by qmin_name and qmax_name
     reduction_config[qmin_name] = qmin_value
     reduction_config[qmax_name] = qmax_value


### PR DESCRIPTION
## Description of work:
Adds an option to change the reference detector for stitching. The wing detector provides a better reference for stitching as wedge0 and wedge1 should be identical at high-q, which lands on the wing detector. The intensities in the low-q can be different for wedge0 and wedge1 as well as the q-ranges, so can make stitching inconsistent.

This PR adds a configuration option to do so and modifies the existing code to map an index associated with the detector.

Check all that apply:
- [X] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [X] Source added/refactored
- [X] Added unit tests
- [X] Added integration tests
- [X] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [10804: [DRTSANS] Option to select reference detector for stitching during wedge anisotropic reduction for BioSANS](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/10804)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
