### PR TITLE
Clarify descriptions in inelastic incoherent documentation

### DIFF
--- a/docs/user/corrections/inelastic_incoherent.rst
+++ b/docs/user/corrections/inelastic_incoherent.rst
@@ -15,7 +15,7 @@ contribution from inelastic scattering [Do2013]_.
 Due to the wavelength dependence of inelastic scattering effects, correcting for them is of
 particular concern for time-of-flight (TOF) pulsed neutron instruments like EQ-SANS, which use a
 broad spectrum of neutron wavelengths. The data reduction for EQ-SANS, therefore, includes optional
-wavelength-dependent corrections for inelastic scattering. $Ecc = R_polar/R_eq$
+wavelength-dependent corrections for inelastic scattering.
 
 Elastic reference normalization
 -------------------------------
@@ -23,7 +23,7 @@ Elastic reference normalization
 Before data reduction, the various data sets must be normalized to equivalent beam exposure.
 The normalization method typically used at EQ-SANS is proton charge on target and measured flux
 spectrum, which requires a pre-measured flux spectrum :math:`\phi(\lambda)`.
-The flux spectrum is measured using a purely elastic sample (carbon black or graphite), however, the
+The flux spectrum is measured with a direct beam impinging on an attenuator, however, the
 actual spectrum may change over time and may be affected by the (weakly) energy-dependent
 scattering cross section.
 
@@ -147,7 +147,8 @@ The following steps describe the calculation procedure for :math:`b` used in `dr
    :math:`\lambda_{ref}` is the shortest wavelength bin and :math:`N` is the number of :math:`q`
    points between :math:`q_{\min}` and :math:`q_{\max}` inclusive.
 
-   #. If ``"incohfit_intensityweighted"`` is ``True``, the compensation will be most accurate in the high-Q range. This is most appropriate when plotting the intensities in a log scale.
+   #. If ``"incohfit_intensityweighted"`` is ``True``, the compensation will be most accurate in the high-Q range.
+      This is most appropriate when large intensity differences are present in the q-range of interest.
 
       .. math::
          b(\lambda_i) = -\frac{1}{N \sum_{q_k=q_{\min}}^{q_{\max}} \frac{1}{I(q_k,\lambda_{ref})}}


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [x] no need for release notes, as these are minor corrections to the documentation
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] ~Source added/refactored~
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~
- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~

**References:**
- ~Links to IBM EWM items:~ 

## :warning: Manual test for the reviewer
No manual test is necessary

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
