### PR TITLE
test passes

### DIFF
--- a/src/drtsans/stitch.py
+++ b/src/drtsans/stitch.py
@@ -65,6 +65,15 @@ def stitch_profiles(profiles, overlaps, target_profile_index=0):
         # Find the data points of the "target" profile in the overlap region
         indexes_in_overlap = (target.mod_q > starting_q) & (target.mod_q < ending_q) & np.isfinite(target.intensity)
         q_values_in_overlap = target.mod_q[indexes_in_overlap]
+
+        if len(q_values_in_overlap) < 2:
+            message = (
+                "Insufficient number of Q values for interpolation to find scale number. "
+                + "Skipping this combined region."
+            )
+            logger.notice(message)
+            raise ValueError(message)
+
         # Interpolate the "to_target" profile intensities at the previously found Q values
         good_values = np.isfinite(to_target.intensity)
         to_target_interpolated = np.interp(
@@ -72,6 +81,15 @@ def stitch_profiles(profiles, overlaps, target_profile_index=0):
             to_target.mod_q[good_values],
             to_target.intensity[good_values],
         )
+
+        if sum(to_target_interpolated) == 0.0:
+            message = (
+                "Stitching interpolation for scale number would result in divide by zero error. "
+                + "Skipping this combined region."
+            )
+            logger.notice(message)
+            raise ValueError(message)
+
         scale = sum(target_profile.intensity[indexes_in_overlap]) / sum(to_target_interpolated)
         if scale <= 0:
             raise ValueError(

--- a/tests/integration/drtsans/test_stitch.py
+++ b/tests/integration/drtsans/test_stitch.py
@@ -412,19 +412,20 @@ def data_test_16b():
 
 
 @pytest.mark.parametrize(
-    "overlaps, throws_error",
+    "overlaps, error_substring",
     [
-        ([[0.01, 0.014], [0.025, 0.029]], False),  # valid format
-        ([0.01, 0.014, 0.025, 0.029], False),  # valid format (for backward compatibility)
-        (None, True),
-        ([], True),
-        ([0.01, 0.014, [0.025, 0.029]], True),
-        ([0.01, 0.014, 0.025], True),
-        ([[0.01, 0.014]], True),
-        ([[0.01], [0.025]], True),
+        ([[0.01, 0.014], [0.025, 0.029]], None),  # valid format
+        ([0.01, 0.014, 0.025, 0.029], None),  # valid format (for backward compatibility)
+        (None, "overlap"),
+        ([], "overlap"),
+        ([0.01, 0.014, [0.025, 0.029]], "overlap"),
+        ([0.01, 0.014, 0.025], "overlap"),
+        ([[0.01, 0.014]], "overlap"),
+        ([[0.01], [0.025]], "overlap"),
+        ([[0.01, 0.01], [0.02, 0.02]], "Insufficient number of Q values"),
     ],
 )
-def test_stitch(data_test_16b, overlaps, throws_error):
+def test_stitch(data_test_16b, overlaps, error_substring):
     r"""
     Test the stitching algorithm ~drtsans.stitch.stitch_profiles.
 
@@ -437,10 +438,10 @@ def test_stitch(data_test_16b, overlaps, throws_error):
     """
     data = data_test_16b  # handy shortcut
     # call the drtsans function
-    if throws_error:
+    if error_substring:
         with pytest.raises(ValueError) as error_info:
             result = stitch_profiles(data.profiles, overlaps, target_profile_index=data.target_index)
-        assert "overlaps" in str(error_info.value)
+        assert error_substring in str(error_info.value)
     else:
         result = stitch_profiles(data.profiles, overlaps, target_profile_index=data.target_index)
         # Check for differences between "result" and "data.stitched" profiles. We check for differences in:
@@ -449,6 +450,7 @@ def test_stitch(data_test_16b, overlaps, throws_error):
         # - Q values
         # - uncertainties in Q values
         # We tolerate differences up to 1% of the stitched profile given in the test data
+
         testing.assert_allclose(result, data.stitched, rtol=data.tolerance, atol=0)
 
 


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/drtsans/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
