### PR TITLE
Inject PlotLy.js version at runtime

### DIFF
--- a/docs/user/autoreduction.rst
+++ b/docs/user/autoreduction.rst
@@ -5,7 +5,7 @@ Autoreduction
 =============
 
 Python scripts for automatic reduction of SANS data are provided in the `scripts/autoreduction/` directory.
-These scripts are designed to be run from the command line and can be used to process data without manual intervention.
+These scripts are designed to be run by the SNS web monitor but also from the command line.
 
 Required arguments for the scripts include:
 
@@ -27,9 +27,8 @@ User can also run the script manually, for instance:
 
     python reduce_EQSANS.py \
         /SNS/EQSANS/IPTS-20196/nexus/EQSANS_89157.nxs.h5 \
-        /tmp \
-        --no_publish --report_file EQSANS_89157.html
+        /tmp --no_publish
 
-This call will generate the report file `EQSANS_89157.html` in the `/tmp` directory,
-and will not publish the results to the live data server.
+This call will not publish the results to the live data server,
+but will save report file `EQSANS_89157.html` in the `/tmp` directory.
 User can point the web browser to the generated report file file:///tmp/EQSANS_89157.html.

--- a/pixi.lock
+++ b/pixi.lock
@@ -1277,8 +1277,8 @@ packages:
   timestamp: 1739569648873
 - pypi: ./
   name: drtsans
-  version: 1.17.0.dev8
-  sha256: 6d24d9f3162beb333187a752fc9f413c53fe853d1e1012a576de8ddf4a99740e
+  version: 1.17.0.dev1
+  sha256: a19e356c027998f19350cd5af9912f4e487f503ee63af365b8d5224454ba85dc
   requires_dist:
   - docutils
   - h5py
@@ -1289,6 +1289,7 @@ packages:
   - mpld3==0.5.10
   - numexpr
   - pandas
+  - requests
   - tinydb
   requires_python: '>=3.11'
   editable: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "mpld3==0.5.10",
     "numexpr",
     "pandas",
+    "requests",
     "tinydb",
     # "finddata>=0.10.1",  there's no pypi package for this. Install it from conda-forge in the "-dev" deploy repo
 ]
@@ -112,6 +113,7 @@ pyqt = ">=5,<6"
 qtpy = ">=2.4.3"
 matplotlib = "*"
 finddata = ">=0.10.1"
+requests = "*"
 
 [tool.pixi.pypi-dependencies]
 drtsans = { path = ".", editable = true }
@@ -128,6 +130,7 @@ pyqt = ">=5,<6"
 qtpy = ">=2.4.3"
 matplotlib = "*"
 finddata = ">=0.10.1"
+requests = "*"
 
 # Environments and features
 

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -93,7 +93,7 @@ def html_wrapper(report: Union[str, None]) -> str:
     Parameters
     ----------
     report : str
-        The HTML content to be wrapped. This should contain on or more <div> elements and possibly
+        The HTML content to be wrapped. This should contain one or more <div> elements and possibly
         summary <table> elements.
 
     Returns

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -137,7 +137,7 @@ def save_plot(report: str, report_file: str):
     Parameters
     ----------
     report
-        The <div> containing the plot to be saved.
+        The HTML content to be saved. This may contain one or more <div> elements and possibly summary <table> elements.
     report_file
         The path to the file where the HTML report will be saved.
 

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -144,7 +144,7 @@ def save_plot(report: str, report_file: str):
     Notes
     -----
     - The saved file includes the Plotly JavaScript library to ensure the plot can be displayed in a web browser.
-    - The function wraps the provided `plot_div` with the required HTML structure.
+    - The function wraps the provided `report` with the required HTML structure.
     """
     with open(report_file, "w") as f:
         f.write(html_wrapper(report))

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -137,7 +137,8 @@ def save_plot(report: str, report_file: str):
     Parameters
     ----------
     report
-        The HTML content to be saved. This may contain one or more <div> elements and possibly summary <table> elements.
+        The HTML content to be saved. This may contain one or more <div> elements
+        and possibly summary <table> elements.
     report_file
         The path to the file where the HTML report will be saved.
 

--- a/tests/unit/autoreduction/test_reduce_EQSANS.py
+++ b/tests/unit/autoreduction/test_reduce_EQSANS.py
@@ -110,7 +110,6 @@ def test_save_plot():
             content = f.read()
         assert "<!DOCTYPE html>" in content
         assert plot_div in content
-        assert "plotly-latest.min.js" in content
         assert "</html>" in content
     finally:
         os.unlink(temp_filename)
@@ -144,20 +143,18 @@ def test_parse_required_arguments():
 
     assert args.events_file == "test_events.nxs"
     assert args.outdir == "/output/dir"
-    assert args.report_file is None
     assert args.no_publish is False
 
 
 def test_parse_all_arguments():
     """Test parsing of all arguments"""
-    test_args = ["test_events.nxs", "/output/dir", "--report_file", "report.html", "--no_publish"]
+    test_args = ["test_events.nxs", "/output/dir", "--no_publish"]
 
     with patch("sys.argv", ["script_name"] + test_args):
         args = reduce_EQSANS.parse_command_arguments()
 
     assert args.events_file == "test_events.nxs"
     assert args.outdir == "/output/dir"
-    assert args.report_file == "report.html"
     assert args.no_publish is True
 
 
@@ -173,8 +170,7 @@ def test_main_with_publish_and_save(
     # Setup mocks
     mock_args = Mock()
     mock_args.events_file = "test.nxs"
-    mock_args.outdir = "/output"
-    mock_args.report_file = "report.html"
+    mock_args.outdir = "/tmp/output"
     mock_args.no_publish = False
     mock_parse_args.return_value = mock_args
 
@@ -205,8 +201,7 @@ def test_main_no_publish_no_save(
     """Test main function with publish and save disabled"""
     mock_args = Mock()
     mock_args.events_file = "test.nxs"
-    mock_args.outdir = "/output"
-    mock_args.report_file = None
+    mock_args.outdir = "/tmp/output"
     mock_args.no_publish = True
     mock_parse_args.return_value = mock_args
 
@@ -223,7 +218,7 @@ def test_main_no_publish_no_save(
     mock_reduce_events.assert_called_once_with("test.nxs")
     mock_plot_heatmap.assert_called_once()
     mock_upload_plot.assert_not_called()
-    mock_save_plot.assert_not_called()
+    mock_save_plot.assert_called()
 
 
 @patch.object(reduce_EQSANS, "parse_command_arguments")
@@ -234,8 +229,7 @@ def test_main_report_file_path_handling(mock_save_plot, mock_plot_heatmap, mock_
     """Test main function handles report file path correctly"""
     mock_args = Mock()
     mock_args.events_file = "test.nxs"
-    mock_args.outdir = "/output"
-    mock_args.report_file = "report.html"  # Just filename
+    mock_args.outdir = "/tmp/output"
     mock_args.no_publish = True
     mock_parse_args.return_value = mock_args
 
@@ -250,7 +244,7 @@ def test_main_report_file_path_handling(mock_save_plot, mock_plot_heatmap, mock_
     reduce_EQSANS.main()
 
     # Check that save_plot was called with the joined path
-    mock_save_plot.assert_called_once_with("<div>plot content</div>", "/output/report.html")
+    mock_save_plot.assert_called_once_with("<div>plot content</div>", "/tmp/output/EQSANS_12345.html")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:

This PR refactors the EQSANS autoreduction script to enhance HTML report generation and updates the documentation. The changes make HTML report saving automatic (always saves to output directory) while maintaining optional publishing to the livedata server.

- Removed the optional `--report_file` argument and made HTML report generation automatic
- Enhanced HTML wrapper functionality with improved Plotly.js version handling and error recovery
- Added `requests` dependency to support the enhanced functionality

Check all that apply:
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [11411](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11411&tab=com.ibm.team.workitem.tab.links)

## :warning: Manual test for the reviewer
Run the autoreduction script:  
```bash
python ./scripts/autoreduction/reduce_EQSANS.py --no_publish ./tests/data/drtsans-data/ornl/sans/sns/eqsans/EQSANS_89157.nxs.h5 /tmp
```
and verify that `file:///tmp/ewm11411.html` can be rendered in the web browser

<img width="400"  src="https://github.com/user-attachments/assets/c484ade6-acd9-414a-b6cd-2710ef4cd201" />

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
