### PR TITLE
Fix bug in periodic time slicing when passing `loadOptions` to `LoadEventNexus`

### DIFF
--- a/src/drtsans/load.py
+++ b/src/drtsans/load.py
@@ -6,6 +6,7 @@ from typing import List, Tuple, Union
 # third party modules
 import mantid
 from mantid.dataobjects import Workspace2D, EventWorkspace
+from mantid.kernel import DateAndTime
 from mantid.simpleapi import mtd
 from mantid.simpleapi import (
     DeleteWorkspace,
@@ -102,10 +103,27 @@ def _insert_periodic_timeslice_log(
     except AttributeError:
         run_start = sample_logs.start_time.value
 
+    try:
+        run_end = sample_logs.run_end.value
+    except AttributeError:
+        run_end = sample_logs.end_time.value
+
+    # get duration between run start and run end
+    # Note: the duration is calculated from run start and end, since the log "duration" is changed
+    # by LoadEventNexus when using parameters FilterByTimeStart and FilterByTimeEnd, and since the
+    # periodic time slicing should be independent of any filtering during loading.
+    duration_start = run_start
+    if isinstance(run_start, str):
+        duration_start = DateAndTime(run_start)
+    duration_end = run_end
+    if isinstance(run_end, str):
+        duration_end = DateAndTime(run_end)
+    duration = duration_end - duration_start
+
     log = periodic_index_log(
         period=time_period,
         interval=time_interval,
-        duration=sample_logs.duration.value,
+        duration=duration.total_seconds(),
         run_start=run_start,
         offset=time_offset,
         step=1.0,

--- a/tests/unit/drtsans/test_load.py
+++ b/tests/unit/drtsans/test_load.py
@@ -39,23 +39,26 @@ def test_monitor_counts():
 
 
 @pytest.mark.parametrize(
-    "ID, time_interval",
+    "ID, time_interval, duration_log",
     [
-        ("integerNslices", 1.5),  # period is a multiple of time slice interval
-        ("nonIntegerNslices", 8.0),  # ... or it is not
+        ("integerNslices", 1.5, 3600.0),  # period is a multiple of time slice interval
+        ("nonIntegerNslices", 8.0, 3600.0),  # ... or it is not
+        # duration smaller than (run_end - run_start) due to FilterByTimeStart and/or FilterByTimeStop
+        ("filteredDuration", 8.0, 2000.0),
     ],
 )
-def test_periodic_timeslice_log(temp_workspace_name, ID, time_interval):
+def test_periodic_timeslice_log(temp_workspace_name, ID, time_interval, duration_log):
     # prepare the input workspace
 
-    duration = 3600.0
+    duration = 3600.0  # actual duration between "run_start" and "run_end"
     time_period = 60.0
     time_offset = 42.0
 
     workspace = CreateWorkspace(dataX=[1.0], dataY=[42.0], OutputWorkspace=temp_workspace_name())
     sample_logs = SampleLogs(workspace)
-    sample_logs.insert("duration", value=duration, unit="second")
+    sample_logs.insert("duration", value=duration_log, unit="second")
     sample_logs.insert("run_start", value="2000-01-01T00:00:00", unit="")
+    sample_logs.insert("run_end", value="2000-01-01T01:00:00", unit="")
 
     # insert the periodic log starting 42 seconds after run_start
     # and having values from zero up to period / time_interval - 1
@@ -82,7 +85,7 @@ def test_periodic_timeslice_log(temp_workspace_name, ID, time_interval):
         # indices range [0 : 60 / 1.5 = 40 : 1]
         assert max(log.value) == (time_period / time_interval) - 1
 
-    elif ID == "nonIntegerNslices":
+    elif ID == "nonIntegerNslices" or ID == "filteredDuration":  # filtering should have no effect on time slicing
         n_periods = np.floor((duration - time_offset) / time_period)
         n_intervals_period = np.ceil(time_period / time_interval)
         n_intervals_remainder = np.ceil(((duration - time_offset) % time_period) / time_interval)


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
conda activate <my_drtsans_dev_environment>
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
