### PR TITLE
fix random number generator seed

### DIFF
--- a/tests/unit/autoreduction/test_reduce_EQSANS.py
+++ b/tests/unit/autoreduction/test_reduce_EQSANS.py
@@ -37,6 +37,7 @@ def simulated_events() -> EventWorkspace:
         An EQSANS events workspace with simulated events
     """
     count = 9
+    rng = np.random.default_rng(7495230093183)  # add seed for deterministic results in tests
     workspace_name = mtd.unique_hidden_name()
     workspace_events = empty_instrument_workspace(
         output_workspace=workspace_name, instrument_name="EQSANS", event_workspace=True
@@ -51,7 +52,7 @@ def simulated_events() -> EventWorkspace:
     insert_background(
         workspace_events,
         # Normal distribution with 5 Angstroms mean wavelength, 0.1 Angstroms standard deviation
-        lambda_distribution=lambda n_events: np.random.normal(loc=5.0, scale=0.1, size=n_events),
+        lambda_distribution=lambda n_events: rng.normal(loc=5.0, scale=0.1, size=n_events),
         flavor="fix count",
         flavor_kwargs={"count": count},
     )


### PR DESCRIPTION
## Description of work:

**Check all that apply:**
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi shell  # activate the environment
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
exit  # exit the environment
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
