### PR TITLE
Add tests with data using the new EQSANS chopper set

### DIFF
--- a/tests/unit/drtsans/tof/eqsans/test_correct_frame.py
+++ b/tests/unit/drtsans/tof/eqsans/test_correct_frame.py
@@ -15,13 +15,28 @@ BandsTuple = namedtuple("BandsTuple", "lead skip")
 
 
 @pytest.mark.datarepo
-def test_transmitted_bands(datarepo_dir, clean_workspace):
+@pytest.mark.parametrize(
+    "filename, lead_range, skip_range",
+    [
+        # four chopper configuration (before 2026)
+        ("EQSANS_101595.nxs.h5", (1.98, 6.16), None),
+        ("EQSANS_86217.nxs.h5", (2.48, 6.78), (10.90, 15.23)),  # frame skipping mode
+        # six chopper configuration (starting 2026)
+        ("EQSANS_176973.nxs.h5", (11.9, 14.98), None),
+        ("EQSANS_176937.nxs.h5", (2.48, 6.13), None),
+        ("EQSANS_178264.nxs.h5", (2.48, 6.13), (9.62, 13.38)),  # frame skipping mode
+    ],
+)
+def test_transmitted_bands(datarepo_dir, clean_workspace, filename, lead_range, skip_range):
     with amend_config(data_dir=datarepo_dir.eqsans):
-        ws = Load(Filename="EQSANS_86217.nxs.h5")
+        ws = Load(Filename=filename)
         clean_workspace(ws)
         bands = correct_frame.transmitted_bands(ws)
-        assert_almost_equal((bands.lead.min, bands.lead.max), (2.48, 6.78), decimal=2)
-        assert_almost_equal((bands.skip.min, bands.skip.max), (10.90, 15.23), decimal=2)
+        assert_almost_equal((bands.lead.min, bands.lead.max), lead_range, decimal=2)
+        if skip_range is not None:
+            assert_almost_equal((bands.skip.min, bands.skip.max), skip_range, decimal=2)
+        else:
+            assert bands.skip is None
 
 
 @pytest.mark.datarepo


### PR DESCRIPTION
## Description of work:

Add regression tests validating the calculated transmitted wavelength bands for EQSANS data files taken after installation of the new choppers. The calculations use the day stamped chopper configurations in `src/drtsans/configuration/EQSANS_chopper_configurations.json`.

**Check all that apply:**
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Story 15020: [drtsans] Update EQSANS chopper configuration values after choppers have been installed](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15020)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi shell  # activate the environment
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
exit  # exit the environment
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
