### PR TITLE
Grant reading access to drtsans-data

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -45,6 +45,11 @@ jobs:
             exit 1
           fi
 
+      - name: Configure Git credentials for code.ornl.gov
+        run: |
+          git config --global credential.helper store
+          echo "https://gitlab-ci-token:${{ secrets.DRTSANS_DATA_READ_TOKEN }}@code.ornl.gov" | git credential approve
+
       - name: Run unit tests
         run: |
           pixi run versioningit -w
@@ -98,7 +103,7 @@ jobs:
           cp *.conda /tmp/local-channel/linux-64
 
       - name: Verify conda package
-        uses: neutrons/conda-actions/pkg-verify@main
+        uses: neutrons/conda-actions/pkg-verify@v1.3
         with:
           package-name: ${{ env.PKG_NAME }}
           local-channel: /tmp/local-channel
@@ -137,7 +142,7 @@ jobs:
           name: artifact-conda-package
 
       - name: Upload package to anaconda
-        uses: neutrons/conda-actions/publish@main
+        uses: neutrons/conda-actions/publish@v1.3
         with:
           anaconda-token: ${{ secrets.ANACONDA_TOKEN }}
           organization: neutrons
@@ -145,7 +150,7 @@ jobs:
 
       - name: Remove old packages
         if: github.ref == 'refs/heads/next'
-        uses: neutrons/conda-actions/pkg-remove@v1
+        uses: neutrons/conda-actions/pkg-remove@v1.3
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
           organization: neutrons

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,10 +46,10 @@ jobs:
           fi
 
       - name: Configure Git credentials for code.ornl.gov
+        env:
+          TOKEN: ${{ secrets.DRTSANS_DATA_READ_TOKEN }}
         run: |
-          git config --global credential.helper store
-          echo "https://gitlab-ci-token:${{ secrets.DRTSANS_DATA_READ_TOKEN }}@code.ornl.gov" >> ~/.git-credentials
-          chmod 600 ~/.git-credentials
+          git config --global url."https://gitlab-ci-token:${TOKEN}@code.ornl.gov/".insteadOf "https://code.ornl.gov/"
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Configure Git credentials for code.ornl.gov
         run: |
           git config --global credential.helper store
-          echo "https://gitlab-ci-token:${{ secrets.DRTSANS_DATA_READ_TOKEN }}@code.ornl.gov" | git credential approve
+          echo "https://gitlab-ci-token:${{ secrets.DRTSANS_DATA_READ_TOKEN }}@code.ornl.gov" >> ~/.git-credentials
+          chmod 600 ~/.git-credentials
 
       - name: Run unit tests
         run: |


### PR DESCRIPTION
## Description of work:
Use a secret granting reading access to `drtsans-data`, and fix the version of action `conda-actions` to `v.1.3`

**Check all that apply:**
- [x] Source added/refactored


## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi shell  # activate the environment
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
exit  # exit the environment
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
