### PR TITLE
Corrections and final bin to use same error weighting scheme

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,544 +1,95 @@
-# GitHub Copilot Instructions for drtsans
+## Workflow
 
-This file configures how GitHub Copilot should assist with development in the
-**drtsans** repository. This project is the ORNL SANS (Small-Angle Neutron
-Scattering) instruments reduction package, used by scientists and researchers
-for neutron scattering data analysis.
+- Assess before acting: read relevant source, tests, conventions, and Mantid dependencies.
+- For non-trivial work, provide a concise itemized plan with testable steps.
+- Implement incrementally and keep the user informed about progress and next steps.
+- When a request is ambiguous, inspect existing patterns first; if still unclear, state the assumption and proceed.
+- Test the smallest relevant behavior first, then broaden testing when needed.
+- Ask permission before invoking a review agent for major features or refactors.
 
-## 🎯 Core Principles
+## Scope Rules
 
-1. **Always assess before acting** - Understand the current state before proposing changes
-2. **Always provide itemized plans** - Break work into clear, testable steps
-3. **Focus on progress tracking** - Users should always know what's happening and what's next
-4. **Test incrementally** - Each step should be testable
-5. **Review after major changes** - Use sub-agents for code review when appropriate
-6. **Document findings** - Keep track of important discoveries and patterns in
-   code comments and documentation
+- Do not refactor unrelated code without permission.
+- Do not add unrequested features, parameters, or abstractions; propose them separately when useful.
+- Do not guess file paths, workspace names, or APIs.
+- Do not use `print()` for runtime messages; use the Mantid logger.
 
----
+## Project Context
 
-## 🚫 What to Avoid
+- Users are scientists working with neutron scattering data.
+- Explain scientific concepts when relevant, such as Q-space, scattering intensity, and data reduction steps.
+- Account for EQSANS, GPSANS, and BIOSANS behavior.
+- Document physical units, including Q in 1/Å, intensity in 1/cm, and wavelength in Å.
 
-- **Do not refactor code that was not requested** — only change what is needed.
-- **Do not add unrequested features** (extra parameters, new abstractions, etc.).
-- **Do not use `print()`** — always use the Mantid logger for messages.
-- **Do not guess at file paths or workspace names** — read the relevant source files first.
-- **Do not skip tests** — every implementation step must be paired with a test.
-- **Do not over-engineer** — prefer simple, readable code that matches the existing style.
+## Technology Stack
 
----
+- **Mantid**: use `mantid.simpleapi` for algorithms, `mantid.kernel` for logging/configuration, and `mantid.api` for workspace types.
+- **Testing**: pytest with pytest-cov, pytest-qt, pytest-mock, pytest-xvfb, and pytest-xdist.
+- **Linting/formatting**: ruff, configured in `pyproject.toml`.
+- **Documentation**: Sphinx with RTD theme.
+- **Package management**: pixi.
+- **Versioning**: versioningit from git tags.
 
-## 🔄 Standard Workflow
+## Project Structure
 
-### Step 1: Assess
-Before responding to any request, examine:
-- Current implementation (read relevant files)
-- Existing tests (unit and integration tests in `tests/`)
-- Related code that might be affected
-- Project structure and conventions
-- Dependencies on Mantid framework
-
-**Output**: Provide a brief summary of what exists now and what needs to change.
-
-**When the request is ambiguous**: check the codebase first — the answer is often in
-existing patterns or related functions. If still unclear, state your assumption explicitly
-(e.g., *"I'm assuming `q_max` defaults to `0.5` based on the existing API — let me know
-if you intended otherwise"*) and proceed. Ask at most one focused question only if the
-ambiguity would cause materially different implementations.
-
-**Example Assessment**:
-```
-Current state:
-- src/drtsans/iq.py has binning functions for I(Q) profiles
-- Unit tests exist in tests/unit/
-- Integration tests use pytest fixtures from tests/conftest.py
-- Code uses Mantid framework for data manipulation
-- Ruff is configured for linting
-
-Need to change:
-- Add new binning method for annular integration
-- Add type hints (already partially present)
-- Add comprehensive tests
-- Update documentation in docs/
-```
-
-### Step 2: Plan
-Create an itemized, actionable plan with:
-- Clear, numbered steps
-- Each step is independently testable
-- Dependencies between steps noted
-- Expected test coverage outlined
-
-**Format**:
-```markdown
-## Itemized Plan
-
-### Core Implementation (3 steps)
-1. **Add new binning function** - Implement in src/drtsans/iq.py
-2. **Add input validation** - Check for valid Q-range and intensity arrays
-3. **Integrate with existing workflow** - Update dataobjects and API
-
-### Testing (2 steps)
-4. **Add unit tests** - Test normal cases, edge cases, error conditions in tests/unit/
-5. **Add integration test** - Test end-to-end workflow in tests/integration/
-
-### Documentation (1 step)
-6. **Update docstrings and docs** - Add usage examples and update API reference
-
-**Testing approach**: After steps 1-3, run step 4 to verify. Step 5 verifies the complete feature.
-```
-
-### Step 3: Implement Incrementally
-- Complete ONE item from the plan at a time
-- Show the user what you're doing: "Implementing step 1: Add new binning function"
-- After each significant step, pause if appropriate
-
-### Step 4: Test
-After implementation:
-- Run relevant tests with pytest
-- Show test results to the user
-- Fix any failures before proceeding
-- Check test coverage with pytest-cov
-
-### Step 5: Review (For Major Changes)
-After completing a significant feature or refactor:
-- Invoke the **Plan** agent (`run_subagent` with `agentName: "Plan"`) to review the changes
-- Provide the review context: what changed and why
-- Address any issues found
-- Update documentation as needed
-
-## 🛠️ Technology Stack
-
-This project uses specific technologies and frameworks:
-
-### Core Framework
-- **Mantid**: Framework for neutron and muon data reduction and analysis
-  - Use `mantid.simpleapi` for algorithms
-  - Use `mantid.kernel` for logging and configuration
-  - Use `mantid.api` for workspace types
-
-### Data Processing
-- **numpy**: Array operations and numerical computing
-- **pandas**: Data manipulation and analysis
-- **h5py**: HDF5 file handling for NeXus files
-- **lmfit**: Curve fitting (version 1.3.3)
-- **matplotlib**: Plotting and visualization
-- **mpld3**: Interactive matplotlib plots
-
-### Development Tools
-- **Testing**: pytest with plugins (pytest-cov, pytest-qt, pytest-mock, pytest-xvfb, pytest-xdist)
-- **Linting/Formatting**: ruff (configured in pyproject.toml)
-- **Documentation**: Sphinx with RTD theme
-- **Pre-commit hooks**: Configured in .pre-commit-config.yaml
-- **Package management**: pixi (conda-based environment management)
-- **Version control**: versioningit for automatic versioning from git tags
-
-### Project Structure
-```
-drtsans/
+```text
+drtsans2/
 ├── src/drtsans/          # Main package source
 ├── tests/                # Test suite
-│   ├── unit/            # Unit tests
-│   ├── integration/     # Integration tests
-│   └── conftest.py      # Pytest fixtures
+│   ├── unit/             # Unit tests
+│   ├── integration/      # Integration tests
+│   └── conftest.py       # Pytest fixtures
 ├── docs/                 # Sphinx documentation
 ├── notebooks/            # Jupyter notebooks for examples
 ├── scripts/              # Utility scripts
 └── data/                 # Test data references
 ```
 
-## 📝 Code Quality Standards
+## Code Standards
 
-### Always Include:
-1. **Type hints** - For function parameters and return values (already in use)
-2. **Docstrings** - For all public functions/classes (numpy/sphinx style preferred)
-3. **Error handling** - Use Mantid logger for warnings and errors
-4. **Input validation** - Check assumptions about data shapes and types
-5. **Comments** - Explain scientific methodology and "why", not "what"
+- Add type hints for function parameters and return values.
+- Add numpy/sphinx-style docstrings for public functions and classes.
+- Validate assumptions about data shapes, types, units, and workspace types.
+- Use Mantid logging for warnings and errors.
+- Explain scientific methodology or intent in comments, not obvious mechanics.
+- Use proper Mantid workspace types, such as `MatrixWorkspace` and `IEventWorkspace`.
+- Support NeXus (`.nxs.h5`) and processed data formats where relevant.
 
-### SANS-Specific Considerations:
-- **Units**: Always document physical units (e.g., Q in 1/Å, I in 1/cm)
-- **Mantid workspaces**: Use proper workspace types (MatrixWorkspace, IEventWorkspace)
-- **Data formats**: Support NeXus (.nxs.h5), processed data formats
-- **Instrument specifics**: Code may handle EQSANS, GPSANS, BIOSANS
+## Pixi
+Run Pixi tasks with permission to write to the repository and Pixi/cache directories.
+In Codex read-only sandboxes, request sandbox escalation with `prefix_rule: ["pixi", "run"]`.
 
-### Code Example Template:
-```python
-from typing import Optional, Union
-import numpy as np
-from mantid.api import MatrixWorkspace
-from mantid.kernel import Logger
+## Testing
 
-logger = Logger("drtsans.module_name")
+- Follow Arrange-Act-Assert.
+- Place unit tests in `tests/unit/` and integration tests in `tests/integration/`.
+- Use fixtures from `tests/conftest.py` and existing pytest markers.
+- Reference test data from `/SNS/EQSANS/shared/sans-backend/data/` or `tests/data/`.
+- Clean up temporary Mantid workspaces.
+- Cache test data where practical to avoid redundant I/O.
 
+Run tests with:
 
-def process_sans_data(
-    input_workspace: Union[str, MatrixWorkspace],
-    q_min: float = 0.001,
-    q_max: float = 0.5,
-    mask_edges: bool = True
-) -> MatrixWorkspace:
-    """
-    Process SANS data and calculate I(Q) profile.
-
-    This function bins scattered intensity as a function of momentum transfer Q,
-    applying proper error propagation and optional edge masking for detector panels.
-
-    Parameters
-    ----------
-    input_workspace : str or MatrixWorkspace
-        Input workspace containing reduced SANS data
-    q_min : float, optional
-        Minimum Q value in 1/Å (default: 0.001)
-    q_max : float, optional
-        Maximum Q value in 1/Å (default: 0.5)
-    mask_edges : bool, optional
-        Whether to mask detector edges (default: True)
-
-    Returns
-    -------
-    MatrixWorkspace
-        Binned I(Q) workspace with proper units
-
-    Raises
-    ------
-    ValueError
-        If Q range is invalid or workspace has incompatible units
-
-    Example
-    -------
-    >>> ws = process_sans_data("EQSANS_68200", q_min=0.005, q_max=0.3)
-    >>> print(ws.readY(0))  # Get intensity values
-
-    Notes
-    -----
-    - Q values are momentum transfer: Q = 4π sin(θ)/λ
-    - Intensities are in absolute units (1/cm) after proper normalization
-    """
-    # Validate inputs
-    if q_min <= 0 or q_max <= q_min:
-        raise ValueError(f"Invalid Q range: [{q_min}, {q_max}]")
-
-    # Convert to workspace if string
-    if isinstance(input_workspace, str):
-        input_workspace = mtd[input_workspace]
-
-    logger.information(f"Processing SANS data: Q range [{q_min}, {q_max}] 1/Å")
-
-    # Implementation...
-
-    return output_workspace
-```
-
-## 🧪 Testing Guidelines
-
-### Test Structure
-Every test should follow Arrange-Act-Assert:
-```python
-def test_bin_intensity_into_q1d_normal_case(clean_workspace):
-    """Test I(Q) binning with typical SANS data."""
-    # Arrange: Set up test workspace and expected results
-    input_ws = clean_workspace("EQSANS_68200")
-    q_min, q_max = 0.005, 0.3
-    expected_bins = 50
-
-    # Act: Call the function
-    result = bin_intensity_into_q1d(input_ws, qmin=q_min, qmax=q_max, bins=expected_bins)
-
-    # Assert: Verify expectations
-    assert result.intensity.shape[0] == expected_bins
-    assert np.all(result.mod_q >= q_min)
-    assert np.all(result.mod_q <= q_max)
-    assert not np.any(np.isnan(result.intensity))
-```
-
-### Test Organization
-- **Unit tests** (`tests/unit/`) - Test individual functions
-- **Integration tests** (`tests/integration/`) - Test complete workflows
-- **Test data** - Referenced from `/SNS/EQSANS/shared/sans-backend/data/` or `tests/data/`
-- **Fixtures** - Use pytest fixtures defined in `tests/conftest.py`
-
-### Test Markers
-Use pytest markers for special test categories:
-```python
-@pytest.mark.datarepo
-def test_with_real_data():
-    """Test using drtsans-data repository."""
-    pass
-
-@pytest.mark.mount_eqsans
-def test_with_sns_mount():
-    """Test requiring /SNS/EQSANS/ data mount."""
-    pass
-```
-
-### Running Tests
 ```bash
-# All tests
-pixi run test
-
-# Unit tests only
 pixi run unit-test
-
-# Integration tests
 pixi run integration-test
-
-# With coverage
-pytest --cov=src --cov-report=term-missing
+pixi run test
 ```
 
-## 🔍 Code Review Process
+## Review
 
-### When to Trigger Review:
-- After implementing a new reduction algorithm
-- After significant refactoring of core modules
-- Before marking major work as complete
-- When requested by user
+Ask permission before review. Use review for new reduction algorithms, significant core refactors, major work before completion, or explicit user requests.
 
-### Review Checklist:
-- [ ] Code follows ruff linting rules
-- [ ] All functions have type hints and docstrings
-- [ ] Tests cover normal, edge, and error cases
-- [ ] Mantid algorithms are used correctly
-- [ ] Physical units are documented and correct
-- [ ] Error messages use Mantid logger
-- [ ] No performance regressions for large datasets
-- [ ] Documentation is updated in docs/
-- [ ] Works with all supported instruments (EQSANS, GPSANS, BIOSANS)
+When approved, invoke the **Plan** agent with `run_subagent` and `agentName: "Plan"`, include what changed and why, then address findings.
 
-## 📚 Documentation Standards
+Review checklist:
 
-### Module Docstrings:
-```python
-"""
-Module for SANS data I(Q) binning operations.
-
-This module provides functions for binning scattered neutron intensity as a
-function of momentum transfer Q, including:
-
-- 1D radial binning: bin_intensity_into_q1d()
-- 2D Cartesian binning: bin_intensity_into_q2d()
-- Wedge selection: select_i_of_q_by_wedge()
-- Annular binning: bin_annular_into_q1d()
-
-Typical workflow:
-    1. Load reduced SANS data
-    2. Choose binning method and parameters
-    3. Apply binning with proper error propagation
-    4. Save results in CanSAS or ASCII format
-
-Example:
-    >>> from drtsans import iq
-    >>> result = iq.bin_intensity_into_q1d(workspace, qmin=0.005, qmax=0.3)
-"""
-```
-
-### Function Docstrings:
-Use numpy/sphinx style (already used in the codebase):
-```python
-def bin_intensity_into_q1d(input_workspace, qmin, qmax, bins=100):
-    """
-    Bin SANS intensity into 1D I(Q) profile.
-
-    Parameters
-    ----------
-    input_workspace : str or MatrixWorkspace
-        Input workspace containing Q values and intensities
-    qmin : float
-        Minimum Q value in 1/Å
-    qmax : float
-        Maximum Q value in 1/Å
-    bins : int, optional
-        Number of Q bins (default: 100)
-
-    Returns
-    -------
-    IQmod
-        Named tuple containing mod_q, intensity, error, delta_mod_q
-    """
-```
-
-## 🚨 Common Scenarios and Responses
-
-### Scenario: User asks to add a new reduction feature
-
-**Response Pattern:**
-```markdown
-Let me assess the current reduction pipeline.
-
-[Read relevant files in src/drtsans/]
-
-**Current state:**
-- Main reduction API is in src/drtsans/api.py
-- I(Q) calculation is in src/drtsans/iq.py
-- Uses Mantid algorithms for low-level operations
-- Tests exist in tests/unit/ and tests/integration/
-
-**Itemized Plan:**
-1. Implement new function in appropriate module
-2. Add Mantid algorithm calls as needed
-3. Add proper error handling with Mantid logger
-4. Add unit tests in tests/unit/
-5. Add integration test with realistic data
-6. Update API documentation in docs/
-
-Proceeding with implementation...
-
-**Step 1: [Description]**
-[Make change, show code with proper docstrings]
-
-**Step 2: [Description]**
-[Make change, ensure Mantid compatibility]
-
-**Testing:**
-[Run tests with pytest]
-
-Completed! Would you like me to:
-- Review the code with the Plan agent?
-- Add example notebook in notebooks/?
-- Update the user documentation?
-```
-
-### Scenario: User reports incorrect I(Q) calculation
-
-**Response Pattern:**
-```markdown
-Let me investigate the I(Q) calculation.
-
-[Read src/drtsans/iq.py and related modules]
-
-**Assessment:**
-- Issue location: src/drtsans/iq.py, line XXX
-- Root cause: [Explanation of physics/algorithm issue]
-- Impact: Affects 1D radial binning for all instruments
-
-**Itemized Fix Plan:**
-1. Correct the momentum transfer calculation
-2. Update error propagation
-3. Add regression test with known good data
-4. Verify against reference results
-
-**Implementing fix:**
-[Make changes with proper scientific justification]
-
-**Testing:**
-[Run unit and integration tests]
-
-Fixed! The calculation now correctly accounts for [scientific detail].
-Added test case to prevent regression.
-```
-
-## ⚡ Efficiency Guidelines
-
-1. **Parallel operations** - Use pytest-xdist for parallel test execution
-2. **Reuse fixtures** - Leverage existing fixtures in tests/conftest.py
-3. **Mantid workspace management** - Clean up temporary workspaces
-4. **Avoid redundant I/O** - Cache test data when possible
-5. **Use pixi tasks** - Leverage pre-configured pixi tasks for common operations
-
-## 🔗 SANS-Specific Integration Patterns
-
-### Loading Data Pattern:
-```python
-from drtsans.load import load_events
-from drtsans.path import abspath
-
-# Load SANS data with proper path resolution
-data_file = abspath("EQSANS_68200", instrument="EQSANS")
-workspace = load_events(data_file, output_workspace="raw_data")
-```
-
-### Reduction Workflow Pattern:
-```python
-from drtsans import iq, sensitivity, solid_angle_correction
-from mantid.simpleapi import mtd
-
-# Typical SANS reduction workflow
-ws = load_events("EQSANS_68200")
-ws = solid_angle_correction(ws)
-ws = apply_sensitivity_correction(ws, sensitivity_file="sensitivity.nxs")
-result = iq.bin_intensity_into_q1d(ws, qmin=0.005, qmax=0.3)
-
-# Save results
-save_ascii_binned_1D("output.dat", "EQSANS 68200", result)
-```
-
-### Working with Mantid Pattern:
-```python
-from mantid.simpleapi import mtd, DeleteWorkspace
-from mantid.kernel import Logger
-
-logger = Logger("drtsans.mymodule")
-
-def process_data(workspace_name):
-    """Process workspace and clean up."""
-    try:
-        ws = mtd[workspace_name]
-        # Process workspace
-        result = do_processing(ws)
-        logger.information(f"Processed {workspace_name}")
-        return result
-    finally:
-        # Clean up temporary workspaces
-        if "__temp" in workspace_name and mtd.doesExist(workspace_name):
-            DeleteWorkspace(workspace_name)
-```
-
-## 📋 Quick Reference
-
-### Assessment Checklist:
-- [ ] Read relevant source files in src/drtsans/
-- [ ] Check existing tests in tests/unit/ and tests/integration/
-- [ ] Review Mantid algorithm usage
-- [ ] Check for instrument-specific code
-- [ ] Review documentation in docs/
-- [ ] Identify affected components
-
-
-### Testing Checklist:
-- [ ] Add unit tests in tests/unit/
-- [ ] Add integration tests if needed
-- [ ] Use appropriate pytest markers
-- [ ] Test with realistic SANS data
-- [ ] Run tests with pixi run test
-- [ ] Check coverage with pytest-cov
-- [ ] Verify with all instruments if applicable
-
-### Review Checklist:
-- [ ] Invoke the Plan agent for major changes
-- [ ] Provide clear context
-- [ ] Address found issues
-- [ ] Update documentation in docs/
-- [ ] Verify Mantid compatibility
-- [ ] Check scientific correctness
-- [ ] Confirm with user
-
-## 🎓 SANS-Specific Guidance
-
-Remember: Users are scientists working with neutron scattering data.
-
-### Always:
-- Explain scientific concepts when relevant (Q-space, scattering intensity, etc.)
-- Reference physical units (Q in 1/Å, I in 1/cm, wavelength in Å)
-- Consider instrument-specific behavior (EQSANS, GPSANS, BIOSANS)
-- Use proper Mantid workspace handling
-- Explain data reduction steps and their purpose
-
-### Example Explanations:
-```
-"I'm adding binning in Q-space, where Q is the momentum transfer
-(Q = 4π sin(θ)/λ). This converts the 2D detector image into a 1D
-I(Q) profile that's easier to analyze and fit."
-
-"Using Mantid's Integration algorithm here to sum counts across
-wavelength bins while properly propagating uncertainties."
-
-"The sensitivity correction accounts for pixel-to-pixel detector
-efficiency variations, ensuring accurate absolute intensities."
-```
-
----
-
-**Remember**: Every interaction should leave the user with working, tested,
-scientifically correct code that properly handles SANS data reduction
-workflows using the Mantid framework.
+- Ruff rules pass.
+- Public functions have type hints and docstrings.
+- Tests cover normal, edge, and error cases.
+- Mantid algorithms and workspace types are used correctly.
+- Physical units are documented and correct.
+- Warnings and errors use Mantid logging.
+- Large datasets do not suffer obvious performance regressions.
+- Documentation is updated when behavior changes.
+- Supported instruments still work: EQSANS, GPSANS, and BIOSANS.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,18 +24,15 @@
 - [ ] code comments added when explaining intent
 
 ### Execution of tests requiring the /SNS and /HFIR filesystems
-It is strongly encouraged that the reviewer runs the following tests in their local machine
-because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
-remotely mounted in their machine.
+It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
+because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
+are mounted in the machine running the tests.
+In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`
+
 
 ```bash
-cd /path/to/my/local/drtsans/repo/
+cd /path/to/my/drtsans/
 git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
 git switch mr<MERGE_REQUEST_NUMBER>
-pixi shell  # activate the environment
-pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
-exit  # exit the environment
+pixi run manual-test
 ```
-In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
-`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
-you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,1 @@
-# Pixi
-
-Run Pixi tasks with permission to write to the repository and Pixi/cache directories.
-In Codex read-only sandboxes, request sandbox escalation with `prefix_rule: ["pixi", "run"]`.
-
-# Testing
-
-Run unit tests with `pixi run unit-test`.
-Run integration tests with `pixi run integration-test`.
-Run the full test suite with `pixi run test`.
+@.github/copilot-instructions.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Pixi
+
+Run Pixi tasks with permission to write to the repository and Pixi/cache directories.
+In Codex read-only sandboxes, request sandbox escalation with `prefix_rule: ["pixi", "run"]`.
+
+# Testing
+
+Run unit tests with `pixi run unit-test`.
+Run integration tests with `pixi run integration-test`.
+Run the full test suite with `pixi run test`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+@.github/copilot-instructions.md

--- a/pixi.lock
+++ b/pixi.lock
@@ -8,6 +8,8 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -146,6 +148,8 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -569,6 +573,8 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1603,10 +1609,9 @@ packages:
   timestamp: 1765193127016
 - pypi: ./
   name: drtsans
-  version: 1.30.0.dev20260601161546
-  sha256: 13f60285a77faabad811241087e58a161609f7a960f646bea391e75189b75ade
+  version: 1.31.0.dev20260610221325
+  sha256: 134a91d3af6c0cdc306f887d20db19ef35fbc8be8bc0e7ee492e4877184d0262
   requires_python: '>=3.12'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
   sha256: a5b51e491fec22bcc1765f5b2c8fff8a97428e9a5a7ee6730095fb9d091b0747
   md5: 057083b06ccf1c2778344b6dabace38b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ test-docs = { cmd = "sphinx-build -M doctest docs docs/_build/html", description
 test = { description = "Run the test suite", cmd = "pytest" }
 unit-test = { description = "Run the unit tests", cmd = "pytest -vv -m 'not mount_eqsans' --cov=src --cov-report=xml:unit_test_coverage.xml --cov-report=term-missing --junitxml=unit_test_results.xml tests/unit/" }
 integration-test = { description = "Run the integration tests", cmd = "pytest -vv -m 'not mount_eqsans' --dist loadscope -n 2 --cov=src --cov-report=xml:integration_test_coverage.xml --cov-report=term-missing --junitxml=integration_test_results.xml tests/integration/" }
+manual-test = {description = "Run tests requiring the SNS mount", cmd = "pytest -vv -m mount_eqsans --dist loadscope -n 2 ./tests/unit/ ./tests/integration/"}
 # Packaging
 conda-build-command = { cmd = "pixi build", description = "Wrapper for building the conda package - used by `conda-build`" }
 conda-build = { description = "Build the conda package", depends-on = [

--- a/src/drtsans/tof/eqsans/reduction_api.py
+++ b/src/drtsans/tof/eqsans/reduction_api.py
@@ -326,7 +326,7 @@ def bin_i_with_correction(
             annular_bin=annular_bin,
             wedges=wedges,
             symmetric_wedges=symmetric_wedges,
-            weighted_errors=True,  # allways use weighted errors when computing the elastic correction
+            weighted_errors=weighted_errors,
             output_wavelength_profile=correction_setup.output_wavelength_dependent_profile,
             output_dir=elastic_dir,
             output_filename=output_filename,
@@ -374,7 +374,7 @@ def bin_i_with_correction(
             annular_bin=annular_bin,
             wedges=wedges,
             symmetric_wedges=symmetric_wedges,
-            weighted_errors=True,  # allways use weighted errors when computing the inelastic correction
+            weighted_errors=weighted_errors,
             select_min_incoherence=correction_setup.select_min_incoherence,
             intensity_weighted=correction_setup.select_intensityweighted[frameskip_frame],
             incoh_qmin=correction_setup.qmin[frameskip_frame],


### PR DESCRIPTION
## Description of work:
This PR updates the EQSANS TOF reduction workflow so the elastic and inelastic corrections use the same error-weighting scheme as the final output binning (instead of always forcing weighted errors). The scheme is determined by the user in the input configuration.
It also establishes copilot-instructions.md as the single source of truth for Codex (AGENTS.md) and Claude (CLAUDE.md)

**Changes:**
- Make elastic and inelastic correction binning respect the `weighted_errors` setting passed through the reduction path.
- Add a `pixi run manual-test` task for running mount-dependent tests.

**Check all that apply:**
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~
- [ ] ~Included a manual test for the reviewer~
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [16490](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16490)

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the following tests in their local machine
because these tests are not run by the GitLab CI. It is assumed that the reviewer has the /SNS and /HFIR filesystems
remotely mounted in their machine.

```bash
cd /path/to/my/local/drtsans/repo/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi shell  # activate the environment
pytest -m mount_eqsans ./tests/unit/ ./tests/integration/
exit  # exit the environment
```
In the above code snippet, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number. Also substitute
`<my_drtsans_dev_environment>` with the name of the conda environment you use for development. It is critical that
you have installed the repo in this conda environment in editable mode with `pip install -e .` or `conda develop .`
