### PR TITLE
Enable EQSANS live reduction to handle temporary sample files

### DIFF
--- a/docs/user/autoreduction.rst
+++ b/docs/user/autoreduction.rst
@@ -135,3 +135,51 @@ Livereduction
 
 Python scripts for automatic reduction of SANS data are provided in the ``scripts/livereduction/`` directory.
 These scripts are meant to be run automatically by the live reduction server, never directly by the User.
+
+How Live Reduction Works
+-------------------------
+
+Live reduction processes neutron scattering data as it is being collected during a run, before the final
+Nexus file is written to disk. The workflow:
+
+1. Mantid's ``LoadLiveData`` algorithm continuously monitors the data stream from the instrument
+2. When new data arrives, it calls the live reduction script (e.g., ``reduce_EQSANS_live_post_proc.py``)
+3. The script receives an EventWorkspace containing the accumulated events
+4. Since no persistent Nexus file exists yet, the script:
+
+   - Saves the EventWorkspace to a temporary processed Nexus file using ``SaveNexusProcessed``
+   - Passes the temporary file path to the standard reduction pipeline
+   - Cleans up the temporary file after reduction completes
+
+5. The reduction results are published to the live data server for immediate viewing
+
+This approach allows live reduction to use the same reduction code as autoreduction, ensuring consistency
+between live and post-run results.
+
+Technical Details
+~~~~~~~~~~~~~~~~~
+
+The live reduction implementation uses a fallback loading mechanism:
+
+- When ``allow_processed_nexus=True`` is passed to ``load_events()``, the loader will:
+
+  1. First attempt to load the file as an event Nexus file using ``LoadEventNexus``
+  2. If that fails, fall back to ``LoadNexusProcessed`` for processed Nexus files
+
+- This allows the same loading code to handle both standard autoreduction (event Nexus files) and
+  live reduction (temporary processed Nexus files)
+
+- Temporary files are created in a secure temporary directory and automatically cleaned up after reduction
+
+Output Files
+~~~~~~~~~~~~
+
+Live reduction generates the same output files as autoreduction, published to the live data server:
+
+- HTML report with plots and reduction parameters
+- 1D and 2D reduced data files (.dat, .h5, .png)
+- Processed workspace (.nxs)
+- Reduction log (.hdf)
+- Configuration file (.json)
+
+If GPR analysis is enabled, GPR-fitted I(Q) profiles are also included in the live reduction results.

--- a/pixi.lock
+++ b/pixi.lock
@@ -8,8 +8,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -148,8 +146,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -560,8 +556,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1543,6 +1537,7 @@ packages:
   version: 1.32.0.dev20260616134216
   sha256: 6c777be05c2ee44a83e25563c6429e8089c0547f4995d51e870a991de01cc69a
   requires_python: '>=3.12'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
   sha256: a5b51e491fec22bcc1765f5b2c8fff8a97428e9a5a7ee6730095fb9d091b0747
   md5: 057083b06ccf1c2778344b6dabace38b

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -375,7 +375,7 @@ def reduce_sample(
     if os.path.exists(reduction_options_path) is False:
         amendment = {
             "iptsNumber": ipts,
-            "sample": {"runNumber": run_number or sample_file},
+            "sample": {"runNumber": sample_file or run_number},
             "outputFileName": f"EQSANS_{run_number}",  # prefix for all output files
             "configuration": {"outputDir": output_dir},
         }

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -320,7 +320,9 @@ def reduce_non_sample(events: EventWorkspace):
     return report
 
 
-def reduce_sample(events: EventWorkspace, output_dir: str, logger: logging.Logger) -> str:
+def reduce_sample(
+    events: EventWorkspace, output_dir: str, logger: logging.Logger, temp_sample_file: str = None
+) -> str:
     """Reduce events from a sample run and generate comprehensive output files and plots.
 
     This function performs the complete reduction workflow for sample runs, including loading
@@ -336,6 +338,10 @@ def reduce_sample(events: EventWorkspace, output_dir: str, logger: logging.Logge
         autoreduce directory, a subdirectory with the run number will be created for outputs.
     logger
         Logger for logging reduction status and errors.
+    temp_sample_file : str, optional
+        Path to a temporary processed Nexus file containing the sample events. When provided
+        (e.g., during live reduction), this file will be used instead of loading from the
+        archive. The file should be created with SaveNexusProcessed.
 
     Returns
     -------
@@ -353,18 +359,25 @@ def reduce_sample(events: EventWorkspace, output_dir: str, logger: logging.Logge
     - Automatically amends reduction parameters with run-specific information
     - Saves reduced data files, HDF5 log, and plots (*.png) to the output directory
     - Saves the final comprehensive reduction options to `reduction_options_{run_number}.json`
+    - When temp_sample_file is provided, the sample is loaded from this file instead of the archive,
+      enabling live reduction before the permanent event file is written.
     """
     run_number = str(events.getRunNumber())  # e.g. "105584"
     ipts = SampleLogs(events).experiment_identifier.value[5:]  # e.g. "12345" when having IPTS-12345
+
+    # Determine if we're doing live reduction (temp_sample_file provided)
+    is_live_reduction = temp_sample_file is not None
 
     # find most appropriate reduction options and amend if necessary
     amendment = {}
     # Example: reduction_options_path == /SNS/EQSANS/IPTS-12345/shared/autoreduce/105584/reduction_options_105584.json
     reduction_options_path = os.path.join(output_dir, f"reduction_options_{run_number}.json")
     if os.path.exists(reduction_options_path) is False:
+        # For live reduction, use the temp file path as the sample runNumber
+        sample_run = temp_sample_file if is_live_reduction else run_number
         amendment = {
             "iptsNumber": ipts,
-            "sample": {"runNumber": run_number},
+            "sample": {"runNumber": sample_run},
             "outputFileName": f"EQSANS_{run_number}",  # prefix for all output files
             "configuration": {"outputDir": output_dir},
         }
@@ -394,7 +407,8 @@ def reduce_sample(events: EventWorkspace, output_dir: str, logger: logging.Logge
     # load files and reduce
     logger.info("reduce_sample: loading input files with load_all_files()")
     os.chdir(AUTOREDUCE_DIR)  # required for load_all_files() to work
-    loaded = load_all_files(input_config)
+    # For live reduction, enable loading of processed Nexus files
+    loaded = load_all_files(input_config, allow_processed_nexus=is_live_reduction)
     logger.info("reduce_sample: reducing with reduce_single_configuration()")
     output = reduce_single_configuration(loaded, input_config)
 
@@ -505,7 +519,9 @@ def match_run_number(path: str) -> str:
     return match.group(1) if match else ""
 
 
-def reduce_events(events: EventWorkspace, output_dir: str, log_context: LogContext) -> str:
+def reduce_events(
+    events: EventWorkspace, output_dir: str, log_context: LogContext, temp_sample_file: str = None
+) -> str:
     """Execute the reduction workflow and generate an HTML report.
 
     Performs the complete reduction process for either sample or non-sample runs,
@@ -523,6 +539,10 @@ def reduce_events(events: EventWorkspace, output_dir: str, log_context: LogConte
         - logger: Logger instance for logging reduction progress and errors
         - logfile: Path to the log file
         - error_buffer: StringIO buffer capturing error-level messages
+    temp_sample_file : str, optional
+        Path to a temporary processed Nexus file containing the sample events. When provided
+        (e.g., during live reduction), this file will be used instead of loading from the
+        archive.
 
     Raises
     ------
@@ -544,7 +564,10 @@ def reduce_events(events: EventWorkspace, output_dir: str, log_context: LogConte
     # reduce events
     report = ""
     try:
-        report += reduce_sample(events, output_dir, logger) if is_sample_run(events) else reduce_non_sample(events)
+        if is_sample_run(events):
+            report += reduce_sample(events, output_dir, logger, temp_sample_file=temp_sample_file)
+        else:
+            report += reduce_non_sample(events)
     except Exception:
         logger.error("Reduction failed")
 

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -321,7 +321,7 @@ def reduce_non_sample(events: EventWorkspace):
 
 
 def reduce_sample(
-    events: EventWorkspace, output_dir: str, logger: logging.Logger, temp_sample_file: str | None = None
+    events: EventWorkspace, output_dir: str, logger: logging.Logger, sample_file: str | None = None
 ) -> str:
     """Reduce events from a sample run and generate comprehensive output files and plots.
 
@@ -338,10 +338,10 @@ def reduce_sample(
         autoreduce directory, a subdirectory with the run number will be created for outputs.
     logger
         Logger for logging reduction status and errors.
-    temp_sample_file : str, optional
-        Path to a temporary processed Nexus file containing the sample events. When provided
-        (e.g., during live reduction), this file will be used instead of loading from the
-        archive. The file should be created with SaveNexusProcessed.
+    sample_file : str, optional
+        Path to a processed Nexus file containing the sample events. When provided
+        (e.g., during live reduction with a temporary file), this file will be used instead
+        of loading from the archive. The file should be created with SaveNexusProcessed.
 
     Returns
     -------
@@ -359,25 +359,23 @@ def reduce_sample(
     - Automatically amends reduction parameters with run-specific information
     - Saves reduced data files, HDF5 log, and plots (*.png) to the output directory
     - Saves the final comprehensive reduction options to `reduction_options_{run_number}.json`
-    - When temp_sample_file is provided, the sample is loaded from this file instead of the archive,
+    - When sample_file is provided, the sample is loaded from this file instead of the archive,
       enabling live reduction before the permanent event file is written.
     """
     run_number = str(events.getRunNumber())  # e.g. "105584"
     ipts = SampleLogs(events).experiment_identifier.value[5:]  # e.g. "12345" when having IPTS-12345
 
-    # Determine if we're doing live reduction (temp_sample_file provided)
-    is_live_reduction = temp_sample_file is not None
+    # Determine if we're doing live reduction (sample_file provided)
+    is_live_reduction = sample_file is not None
 
     # find most appropriate reduction options and amend if necessary
     amendment = {}
     # Example: reduction_options_path == /SNS/EQSANS/IPTS-12345/shared/autoreduce/105584/reduction_options_105584.json
     reduction_options_path = os.path.join(output_dir, f"reduction_options_{run_number}.json")
     if os.path.exists(reduction_options_path) is False:
-        # For live reduction, use the temp file path as the sample runNumber
-        sample_run = temp_sample_file if is_live_reduction else run_number
         amendment = {
             "iptsNumber": ipts,
-            "sample": {"runNumber": sample_run},
+            "sample": {"runNumber": run_number or sample_file},
             "outputFileName": f"EQSANS_{run_number}",  # prefix for all output files
             "configuration": {"outputDir": output_dir},
         }
@@ -402,6 +400,12 @@ def reduce_sample(
         raw_options = json.load(f)
     input_config = reduction_parameters(raw_options, validate=False, permissible=True)
     input_config = update_reduction_parameters(input_config, amendment, validate=True, permissible=True)
+
+    # For live reduction, ensure normalization is not set to 'Monitor' (not supported)
+    if is_live_reduction and input_config.get("normalization") == "Monitor":
+        logger.warning("Normalization by Monitor is not supported during live reduction. Switching to 'Total charge'.")
+        input_config["normalization"] = "Total charge"
+
     final_input_config = deepcopy(input_config)  # input_config will be modified during reduction
 
     # load files and reduce
@@ -520,7 +524,7 @@ def match_run_number(path: str) -> str:
 
 
 def reduce_events(
-    events: EventWorkspace, output_dir: str, log_context: LogContext, temp_sample_file: str | None = None
+    events: EventWorkspace, output_dir: str, log_context: LogContext, sample_file: str | None = None
 ) -> str:
     """Execute the reduction workflow and generate an HTML report.
 
@@ -539,10 +543,10 @@ def reduce_events(
         - logger: Logger instance for logging reduction progress and errors
         - logfile: Path to the log file
         - error_buffer: StringIO buffer capturing error-level messages
-    temp_sample_file : str, optional
-        Path to a temporary processed Nexus file containing the sample events. When provided
-        (e.g., during live reduction), this file will be used instead of loading from the
-        archive.
+    sample_file : str, optional
+        Path to a processed Nexus file containing the sample events. When provided
+        (e.g., during live reduction with a temporary file), this file will be used instead
+        of loading from the archive.
 
     Raises
     ------
@@ -565,7 +569,7 @@ def reduce_events(
     report = ""
     try:
         if is_sample_run(events):
-            report += reduce_sample(events, output_dir, logger, temp_sample_file=temp_sample_file)
+            report += reduce_sample(events, output_dir, logger, sample_file=sample_file)
         else:
             report += reduce_non_sample(events)
     except Exception:

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -321,7 +321,7 @@ def reduce_non_sample(events: EventWorkspace):
 
 
 def reduce_sample(
-    events: EventWorkspace, output_dir: str, logger: logging.Logger, temp_sample_file: str = None
+    events: EventWorkspace, output_dir: str, logger: logging.Logger, temp_sample_file: str | None = None
 ) -> str:
     """Reduce events from a sample run and generate comprehensive output files and plots.
 
@@ -520,7 +520,7 @@ def match_run_number(path: str) -> str:
 
 
 def reduce_events(
-    events: EventWorkspace, output_dir: str, log_context: LogContext, temp_sample_file: str = None
+    events: EventWorkspace, output_dir: str, log_context: LogContext, temp_sample_file: str | None = None
 ) -> str:
     """Execute the reduction workflow and generate an HTML report.
 

--- a/scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py
+++ b/scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py
@@ -69,10 +69,10 @@ def livereduce(events: EventWorkspace, publish=True):
                 # This is necessary because the reduction pipeline expects to load the sample
                 # data from a file, but during live reduction the permanent event file
                 # doesn't exist yet.
-                temp_sample_file = os.path.join(temp_dir, f"EQSANS_{run}_live.nxs")
+                sample_file = os.path.join(temp_dir, f"EQSANS_{run}_live.nxs")
                 try:
-                    logger.info(f"Saving live events to temporary file: {temp_sample_file}")
-                    SaveNexusProcessed(InputWorkspace=events, Filename=temp_sample_file)
+                    logger.info(f"Saving live events to temporary file: {sample_file}")
+                    SaveNexusProcessed(InputWorkspace=events, Filename=sample_file)
                 except Exception as e:
                     error_msg = f"Failed to save live events to temporary file: {str(e)}"
                     logger.error(error_msg)
@@ -85,7 +85,7 @@ def livereduce(events: EventWorkspace, publish=True):
                     return
 
                 # Reduce the events using the temporary file
-                report = reduce_events(events, temp_dir, log_context, temp_sample_file=temp_sample_file)
+                report = reduce_events(events, temp_dir, log_context, sample_file=sample_file)
                 report += footer(events, output_dir, log_context)  # notice we pass output_dir here
                 save_report(report, os.path.join(temp_dir, f"EQSANS_{run}.html"), logger)  # save to disk
                 if events_file_exists(events):

--- a/scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py
+++ b/scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py
@@ -70,8 +70,19 @@ def livereduce(events: EventWorkspace, publish=True):
                 # data from a file, but during live reduction the permanent event file
                 # doesn't exist yet.
                 temp_sample_file = os.path.join(temp_dir, f"EQSANS_{run}_live.nxs")
-                logger.info(f"Saving live events to temporary file: {temp_sample_file}")
-                SaveNexusProcessed(InputWorkspace=events, Filename=temp_sample_file)
+                try:
+                    logger.info(f"Saving live events to temporary file: {temp_sample_file}")
+                    SaveNexusProcessed(InputWorkspace=events, Filename=temp_sample_file)
+                except Exception as e:
+                    error_msg = f"Failed to save live events to temporary file: {str(e)}"
+                    logger.error(error_msg)
+                    # Create an error report so live reduction service has a diagnostic artifact
+                    report = f"<h1>Live Reduction Error</h1><p>{error_msg}</p><pre>{str(e)}</pre>"
+                    report += footer(events, output_dir, log_context)
+                    save_report(report, os.path.join(temp_dir, f"EQSANS_{run}.html"), logger)
+                    if publish:
+                        upload_report(temp_dir, output_dir, logger)
+                    return
 
                 # Reduce the events using the temporary file
                 report = reduce_events(events, temp_dir, log_context, temp_sample_file=temp_sample_file)

--- a/scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py
+++ b/scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py
@@ -13,7 +13,7 @@ from os import makedirs
 from shutil import copytree
 import tempfile
 
-from mantid.simpleapi import LoadEmptyInstrument
+from mantid.simpleapi import LoadEmptyInstrument, SaveNexusProcessed
 from mantid.dataobjects import EventWorkspace
 
 from drtsans.path import add_to_sys_path
@@ -65,7 +65,16 @@ def livereduce(events: EventWorkspace, publish=True):
         with configure_error_buffer() as error_buffer:
             log_context = LogContext(logger=logger, logfile=LOG_FILE, error_buffer=error_buffer)
             with tempfile.TemporaryDirectory(prefix="livereduce_") as temp_dir:
-                report = reduce_events(events, temp_dir, log_context)
+                # Save the EventWorkspace to a temporary processed Nexus file.
+                # This is necessary because the reduction pipeline expects to load the sample
+                # data from a file, but during live reduction the permanent event file
+                # doesn't exist yet.
+                temp_sample_file = os.path.join(temp_dir, f"EQSANS_{run}_live.nxs")
+                logger.info(f"Saving live events to temporary file: {temp_sample_file}")
+                SaveNexusProcessed(InputWorkspace=events, Filename=temp_sample_file)
+
+                # Reduce the events using the temporary file
+                report = reduce_events(events, temp_dir, log_context, temp_sample_file=temp_sample_file)
                 report += footer(events, output_dir, log_context)  # notice we pass output_dir here
                 save_report(report, os.path.join(temp_dir, f"EQSANS_{run}.html"), logger)  # save to disk
                 if events_file_exists(events):

--- a/src/drtsans/load.py
+++ b/src/drtsans/load.py
@@ -9,9 +9,9 @@ from mantid.kernel import Logger, amend_config
 from mantid.simpleapi import (
     AddSampleLogMultiple,
     FilterEvents,
-    Load,
     LoadEventNexus,
     LoadEventAsWorkspace2D,
+    LoadNexusProcessed,
     MergeRuns,
     mtd,
     ScaleInstrumentComponent,
@@ -125,8 +125,8 @@ def load_events(
     allow_processed_nexus: bool
         When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
         in addition to event Nexus files. This is useful for live reduction where events
-        are saved to a temporary file. If LoadEventNexus fails, falls back to Mantid's
-        generic Load algorithm which can handle both file types.
+        are saved to a temporary file. If LoadEventNexus fails, falls back to
+        LoadNexusProcessed algorithm for processed Nexus files.
     kwargs: dict
         Additional positional arguments for loading algorithm;
         :ref:`LoadEventNexus <algm-LoadEventNexus-v1>`,
@@ -171,17 +171,17 @@ def load_events(
                 LoadEventAsWorkspace2D(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
             else:
                 # Try LoadEventNexus first; if allow_processed_nexus is True and it fails,
-                # fall back to Mantid's generic Load algorithm which can handle processed Nexus files
+                # fall back to LoadNexusProcessed which can handle processed Nexus files
                 # (e.g., files created by SaveNexusProcessed during live reduction)
                 if allow_processed_nexus:
                     try:
                         LoadEventNexus(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
                     except RuntimeError as e:
-                        logger.notice(f"LoadEventNexus failed for {filename}, trying generic Load algorithm: {str(e)}")
-                        # Fall back to generic Load algorithm which auto-detects file type
-                        # Note: some kwargs specific to LoadEventNexus may not be valid for Load
+                        logger.notice(f"LoadEventNexus failed for {filename}, trying LoadNexusProcessed: {str(e)}")
+                        # Fall back to LoadNexusProcessed for processed Nexus files
+                        # Note: some kwargs specific to LoadEventNexus may not be valid for LoadNexusProcessed
                         load_kwargs = {k: v for k, v in kwargs.items() if k not in ["LoadNexusInstrumentXML"]}
-                        Load(Filename=filename, OutputWorkspace=output_workspace, **load_kwargs)
+                        LoadNexusProcessed(Filename=filename, OutputWorkspace=output_workspace, **load_kwargs)
                 else:
                     LoadEventNexus(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
 

--- a/src/drtsans/load.py
+++ b/src/drtsans/load.py
@@ -42,6 +42,16 @@ __all__ = ["load_events", "sum_data", "load_and_split", "move_instrument"]
 
 logger = Logger("drtsans.load")
 
+# Valid arguments for LoadNexusProcessed algorithm
+LOAD_NEXUS_PROCESSED_ARGS = {
+    "SpectrumMin",
+    "SpectrumMax",
+    "SpectrumList",
+    "EntryNumber",
+    "LoadHistory",
+    "FastMultiPeriod",
+}
+
 
 def __monitor_counts(filename, monitor_name="monitor1"):
     r"""Get the total number of counts in a single monitor
@@ -124,9 +134,9 @@ def load_events(
         When true, return the ``output_workspace`` if it already exists
     allow_processed_nexus: bool
         When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
-        in addition to event Nexus files. This is useful for live reduction where events
-        are saved to a temporary file. If LoadEventNexus fails, falls back to
-        LoadNexusProcessed algorithm for processed Nexus files.
+        in addition to event Nexus files. This is useful for live reduction for time-of-flight
+        instruments where events are saved to a temporary file. If LoadEventNexus fails, falls
+        back to LoadNexusProcessed algorithm for processed Nexus files.
     kwargs: dict
         Additional positional arguments for loading algorithm;
         :ref:`LoadEventNexus <algm-LoadEventNexus-v1>`,
@@ -170,17 +180,12 @@ def load_events(
                 # LoadEventAsWorkspace2D does not have MetaDataOnly as an argument parameter  "MetaDataOnly"
                 LoadEventAsWorkspace2D(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
             else:
-                # Try LoadEventNexus first; if allow_processed_nexus is True and it fails,
-                # fall back to LoadNexusProcessed which can handle processed Nexus files
-                # (e.g., files created by SaveNexusProcessed during live reduction)
                 if allow_processed_nexus:
                     try:
                         LoadEventNexus(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
                     except RuntimeError as e:
                         logger.notice(f"LoadEventNexus failed for {filename}, trying LoadNexusProcessed: {str(e)}")
-                        # Fall back to LoadNexusProcessed for processed Nexus files
-                        # Note: some kwargs specific to LoadEventNexus may not be valid for LoadNexusProcessed
-                        load_kwargs = {k: v for k, v in kwargs.items() if k not in ["LoadNexusInstrumentXML"]}
+                        load_kwargs = {k: v for k, v in kwargs.items() if k in LOAD_NEXUS_PROCESSED_ARGS}
                         LoadNexusProcessed(Filename=filename, OutputWorkspace=output_workspace, **load_kwargs)
                 else:
                     LoadEventNexus(Filename=filename, OutputWorkspace=output_workspace, **kwargs)

--- a/src/drtsans/load.py
+++ b/src/drtsans/load.py
@@ -9,6 +9,7 @@ from mantid.kernel import Logger, amend_config
 from mantid.simpleapi import (
     AddSampleLogMultiple,
     FilterEvents,
+    Load,
     LoadEventNexus,
     LoadEventAsWorkspace2D,
     MergeRuns,
@@ -83,6 +84,7 @@ def load_events(
     detector_offset=0.0,
     sample_offset=0.0,
     reuse_workspace=False,
+    allow_processed_nexus=False,
     **kwargs,
 ):
     r"""
@@ -120,6 +122,11 @@ def load_events(
         at the origin of coordinates. Positive moves the sample downstream.
     reuse_workspace: bool
         When true, return the ``output_workspace`` if it already exists
+    allow_processed_nexus: bool
+        When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
+        in addition to event Nexus files. This is useful for live reduction where events
+        are saved to a temporary file. If LoadEventNexus fails, falls back to Mantid's
+        generic Load algorithm which can handle both file types.
     kwargs: dict
         Additional positional arguments for loading algorithm;
         :ref:`LoadEventNexus <algm-LoadEventNexus-v1>`,
@@ -163,7 +170,20 @@ def load_events(
                 # LoadEventAsWorkspace2D does not have MetaDataOnly as an argument parameter  "MetaDataOnly"
                 LoadEventAsWorkspace2D(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
             else:
-                LoadEventNexus(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
+                # Try LoadEventNexus first; if allow_processed_nexus is True and it fails,
+                # fall back to Mantid's generic Load algorithm which can handle processed Nexus files
+                # (e.g., files created by SaveNexusProcessed during live reduction)
+                if allow_processed_nexus:
+                    try:
+                        LoadEventNexus(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
+                    except RuntimeError as e:
+                        logger.notice(f"LoadEventNexus failed for {filename}, trying generic Load algorithm: {str(e)}")
+                        # Fall back to generic Load algorithm which auto-detects file type
+                        # Note: some kwargs specific to LoadEventNexus may not be valid for Load
+                        load_kwargs = {k: v for k, v in kwargs.items() if k not in ["LoadNexusInstrumentXML"]}
+                        Load(Filename=filename, OutputWorkspace=output_workspace, **load_kwargs)
+                else:
+                    LoadEventNexus(Filename=filename, OutputWorkspace=output_workspace, **kwargs)
 
         if isinstance(scale_components, dict):
             for component, scalings in scale_components.items():

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -112,7 +112,7 @@ def _get_configuration_file_parameters(sample_run, directory=None):
 
 
 @namedtuplefy
-def load_all_files(reduction_input, prefix="", load_params=None):
+def load_all_files(reduction_input, prefix="", load_params=None, allow_processed_nexus=False):
     r"""
     overwrites metadata for sample workspace
 
@@ -125,6 +125,19 @@ def load_all_files(reduction_input, prefix="", load_params=None):
     -  output: load_params, reduction_input
     5. load and optionally slice sample runs
     6. load other runs: bkgd, empty, sample_trans, bkgd_trans
+
+    Parameters
+    ----------
+    reduction_input : dict
+        Dictionary containing all reduction parameters
+    prefix : str
+        Prefix for workspace names
+    load_params : dict, optional
+        Parameters for loading workspaces
+    allow_processed_nexus : bool
+        When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
+        for the sample run. This is useful for live reduction where events are saved to a
+        temporary file.
 
     Returned namedtuple:
         - sample, background, empty, sample_transmission, background_transmission: namedtuple(data[ws], monitor[ws])
@@ -214,6 +227,8 @@ def load_all_files(reduction_input, prefix="", load_params=None):
     # check for time/log slicing
     timeslice, logslice, polarized = resolve_slicing(reduction_input)
     load_params_sample = {**sample_load_options, **load_params}
+    # Enable loading of processed Nexus files for sample (used in live reduction)
+    load_params_sample["allow_processed_nexus"] = allow_processed_nexus
     # Load (and optionally slice) sample runs
     # special loading case for sample to allow the slicing options
     logslice_data_dict = {}

--- a/src/drtsans/tof/eqsans/load.py
+++ b/src/drtsans/tof/eqsans/load.py
@@ -119,6 +119,7 @@ def load_events(
     data_dir=None,
     output_workspace=None,
     output_suffix="",
+    allow_processed_nexus=False,
     **kwargs,
 ):
     r"""
@@ -160,6 +161,10 @@ def load_events(
     output_suffix: str
         If the ``output_workspace`` is not specified, this is appended to the automatically generated
         output workspace name.
+    allow_processed_nexus: bool
+        When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
+        in addition to event Nexus files. This is useful for live reduction where events
+        are saved to a temporary file.
     kwargs: dict
         Additional positional arguments for :ref:`LoadEventNexus <algm-LoadEventNexus-v1>`.
 
@@ -172,6 +177,7 @@ def load_events(
     output_workspace = generic_load_events(
         run=run,
         data_dir=data_dir,
+        allow_processed_nexus=allow_processed_nexus,
         output_workspace=output_workspace,
         output_suffix=output_suffix,
         scale_components=scale_components,
@@ -214,6 +220,7 @@ def load_events_and_histogram(
     monitors=False,
     keep_events=True,
     sample_bands=None,
+    allow_processed_nexus=False,
     **kwargs,
 ):
     r"""Load events from one or more NeXus files with initial corrections
@@ -286,6 +293,10 @@ def load_events_and_histogram(
         The final histogram will be an EventsWorkspace if True.
     sample_bands: bands or None
         sample bands
+    allow_processed_nexus: bool
+        When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
+        in addition to event Nexus files. This is useful for live reduction where events
+        are saved to a temporary file.
     kwargs: dict
         Additional positional arguments for :ref:`LoadEventNexus <algm-LoadEventNexus-v1>`.
 
@@ -325,6 +336,7 @@ def load_events_and_histogram(
             data_dir=data_dir,
             output_workspace=output_workspace,
             output_suffix=output_suffix,
+            allow_processed_nexus=allow_processed_nexus,
             **kwargs,
         )
 
@@ -385,6 +397,7 @@ def load_events_and_histogram(
                 data_dir=data_dir,
                 output_workspace=temp_workspace_name,
                 output_suffix=output_suffix,
+                allow_processed_nexus=allow_processed_nexus,
                 **kwargs,
             )
             if center_x is None or center_y is None:

--- a/tests/integration/livereduction/test_reduce_EQSANS_live_post_proc.py
+++ b/tests/integration/livereduction/test_reduce_EQSANS_live_post_proc.py
@@ -2,9 +2,10 @@ import pathlib
 from unittest import mock
 import shutil
 
-from mantid.simpleapi import LoadEventNexus, mtd
+from mantid.simpleapi import LoadEventNexus, SaveNexusProcessed, mtd
 import pytest
 
+from drtsans.load import load_events
 from drtsans.path import load_module
 
 # Add the repo's root directory to the path
@@ -42,6 +43,40 @@ def test_livereduce(tmp_path):
 
     for expected in expected_files:
         assert (tmp_path / expected).is_file(), f"{expected} was not created."
+
+
+@pytest.mark.mount_eqsans
+def test_save_and_load_processed_nexus_round_trip(tmp_path):
+    """Test that SaveNexusProcessed + load_events with allow_processed_nexus works.
+
+    This test verifies the round-trip of saving an EventWorkspace to a processed
+    Nexus file and loading it back using the new allow_processed_nexus functionality.
+    This is the core mechanism used for live reduction.
+    """
+    # Load original events
+    original_ws_name = mtd.unique_hidden_name()
+    original_events = LoadEventNexus(
+        Filename="/SNS/EQSANS/IPTS-35884/nexus/EQSANS_172835.nxs.h5", OutputWorkspace=original_ws_name
+    )
+
+    # Save to a processed Nexus file (simulating what live reduction does)
+    temp_file = str(tmp_path / "EQSANS_172835_live.nxs")
+    SaveNexusProcessed(InputWorkspace=original_events, Filename=temp_file)
+
+    # Load back using the new allow_processed_nexus parameter
+    loaded_ws_name = mtd.unique_hidden_name()
+    loaded_events = load_events(
+        run=temp_file,
+        output_workspace=loaded_ws_name,
+        allow_processed_nexus=True,
+    )
+
+    # Verify the loaded workspace has the same number of histograms
+    assert loaded_events.getNumberHistograms() == original_events.getNumberHistograms()
+
+    # Clean up
+    mtd.remove(original_ws_name)
+    mtd.remove(loaded_ws_name)
 
 
 if __name__ == "__main__":

--- a/tests/unit/drtsans/test_load_processed_nexus.py
+++ b/tests/unit/drtsans/test_load_processed_nexus.py
@@ -1,0 +1,142 @@
+"""
+Unit tests for the allow_processed_nexus functionality in load_events.
+
+This tests the ability to load processed Nexus files (saved with SaveNexusProcessed)
+as a fallback when LoadEventNexus fails. This is used for live reduction where
+the sample events are saved to a temporary file.
+"""
+
+import pytest
+from mantid.simpleapi import (
+    DeleteWorkspace,
+    MoveInstrumentComponent,
+    SaveNexusProcessed,
+    mtd,
+)
+import numpy as np
+
+from drtsans.instruments import empty_instrument_workspace
+from drtsans.load import load_events
+from drtsans.samplelogs import SampleLogs
+from drtsans.simulated_events import insert_background
+
+
+@pytest.fixture(scope="module")
+def simulated_eqsans_events():
+    """Create a simulated EQSANS instrument workspace with events.
+
+    Returns
+    -------
+    EventWorkspace
+        An EQSANS events workspace with simulated events
+    """
+    count = 9
+    workspace_name = mtd.unique_hidden_name()
+    workspace_events = empty_instrument_workspace(
+        output_workspace=workspace_name, instrument_name="EQSANS", event_workspace=True
+    )
+    workspace_events.getAxis(0).setUnit("TOF")
+    workspace_events.getAxis(1).setUnit("Label")
+    MoveInstrumentComponent(Workspace=workspace_name, ComponentName="detector1", Z=5.0)
+    sample_logs = SampleLogs(workspace_events)
+    sample_logs.insert("start_time", "2023-08-01 00:00:00")
+    sample_logs.insert("run_number", 99999)
+    sample_logs.insert("experiment_identifier", "IPTS-99999")
+    insert_background(
+        workspace_events,
+        # Normal distribution with 5 Angstroms mean wavelength, 0.1 Angstroms standard deviation
+        lambda_distribution=lambda n_events: np.random.normal(loc=5.0, scale=0.1, size=n_events),
+        flavor="fix count",
+        flavor_kwargs={"count": count},
+    )
+    yield workspace_events
+    # Cleanup
+    if mtd.doesExist(workspace_name):
+        DeleteWorkspace(workspace_name)
+
+
+@pytest.fixture
+def temp_processed_nexus_file(simulated_eqsans_events, tmp_path):
+    """Save simulated events to a temporary processed Nexus file.
+
+    Parameters
+    ----------
+    simulated_eqsans_events : EventWorkspace
+        The simulated EQSANS events workspace
+    tmp_path : Path
+        Pytest fixture for temporary directory
+
+    Returns
+    -------
+    str
+        Path to the temporary processed Nexus file
+    """
+    temp_file = str(tmp_path / "EQSANS_99999_live.nxs")
+    SaveNexusProcessed(InputWorkspace=simulated_eqsans_events, Filename=temp_file)
+    return temp_file
+
+
+def test_load_events_with_processed_nexus_fallback(temp_processed_nexus_file, temp_workspace_name):
+    """Test that load_events can load a processed Nexus file when allow_processed_nexus=True.
+
+    This simulates the live reduction scenario where events are saved to a temporary
+    processed Nexus file.
+    """
+    ws_name = temp_workspace_name()
+
+    # Load the processed Nexus file using the fallback mechanism
+    ws = load_events(
+        run=temp_processed_nexus_file,
+        output_workspace=ws_name,
+        allow_processed_nexus=True,
+    )
+
+    # Verify the workspace was loaded successfully
+    assert ws is not None
+    assert mtd.doesExist(ws_name)
+    # Check basic workspace properties
+    assert ws.getNumberHistograms() > 0
+
+
+def test_load_events_without_processed_nexus_fails(temp_processed_nexus_file, temp_workspace_name):
+    """Test that load_events fails when trying to load a processed Nexus file
+    without allow_processed_nexus=True.
+
+    This is the expected behavior for normal autoreduction which uses event Nexus files.
+    """
+    ws_name = temp_workspace_name()
+
+    # Attempting to load without allow_processed_nexus should fail
+    with pytest.raises(RuntimeError):
+        load_events(
+            run=temp_processed_nexus_file,
+            output_workspace=ws_name,
+            allow_processed_nexus=False,
+        )
+
+
+def test_load_events_allow_processed_nexus_preserves_workspace_properties(
+    simulated_eqsans_events, temp_processed_nexus_file, temp_workspace_name
+):
+    """Test that loading a processed Nexus file preserves workspace properties.
+
+    Verifies that SaveNexusProcessed + Load gives back an equivalent workspace.
+    """
+    ws_name = temp_workspace_name()
+
+    # Load the processed Nexus file
+    loaded_ws = load_events(
+        run=temp_processed_nexus_file,
+        output_workspace=ws_name,
+        allow_processed_nexus=True,
+    )
+
+    # Compare with the original workspace
+    original_ws = simulated_eqsans_events
+
+    # Check that the number of histograms matches
+    assert loaded_ws.getNumberHistograms() == original_ws.getNumberHistograms()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/livereduction/test_reduce_EQSANS_live_post_proc.py
+++ b/tests/unit/livereduction/test_reduce_EQSANS_live_post_proc.py
@@ -118,6 +118,9 @@ def test_livereduce(simulated_events, tmp_path):
     mock_reduce_module.LogContext = mock.MagicMock()
     sys.modules["reduce_EQSANS"] = mock_reduce_module
 
+    # Mock SaveNexusProcessed to track calls
+    mock_save_nexus = mock.MagicMock()
+
     try:
         # import there so mocking the module's symbols won't affect other tests
         livescript = load_module(_root_dir / "scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py")
@@ -125,9 +128,64 @@ def test_livereduce(simulated_events, tmp_path):
         livescript.events_file_exists = mock.MagicMock(return_value=False)
         livescript.copytree = mock_copytree
         livescript.makedirs = mock_makedirs
+        livescript.SaveNexusProcessed = mock_save_nexus
         livescript.livereduce(simulated_events)
+
+        # Verify SaveNexusProcessed was called with the events workspace
+        assert mock_save_nexus.called, "SaveNexusProcessed should be called for live reduction"
+        save_call_args = mock_save_nexus.call_args
+        assert save_call_args[1]["InputWorkspace"] == simulated_events
+        # Verify the temp file path contains the run number
+        assert "EQSANS_12345_live.nxs" in save_call_args[1]["Filename"]
+
+        # Verify reduce_events was called with temp_sample_file parameter
+        reduce_events_call = mock_reduce_module.reduce_events
+        assert reduce_events_call.called
+        call_kwargs = reduce_events_call.call_args[1]
+        assert "temp_sample_file" in call_kwargs
+        assert "EQSANS_12345_live.nxs" in call_kwargs["temp_sample_file"]
+
         assert (tmp_path / "EQSANS_12345.html").read_text() == "<report><footer>"
     finally:  # Clean up
+        sys.modules.pop("reduce_EQSANS", None)
+
+
+def test_livereduce_temp_file_created_in_temp_dir(simulated_events, tmp_path):
+    """Test that the temporary sample file is created within the temporary directory."""
+    temp_files_created = []
+
+    def mock_save_nexus(InputWorkspace, Filename):
+        temp_files_created.append(Filename)
+
+    mock_add_to_sys_path = mock.MagicMock()
+    mock_add_to_sys_path.__enter__ = lambda self, *_: self
+    mock_add_to_sys_path.__exit__ = lambda *_: None
+
+    mock_reduce_module = types.ModuleType("reduce_EQSANS")
+    mock_reduce_module.reduce_events = mock.MagicMock(return_value="<report>")
+    mock_reduce_module.footer = mock.MagicMock(return_value="<footer>")
+    mock_reduce_module.save_report = mock.MagicMock()
+    mock_reduce_module.upload_report = mock.MagicMock()
+    mock_reduce_module.LogContext = mock.MagicMock()
+    sys.modules["reduce_EQSANS"] = mock_reduce_module
+
+    try:
+        livescript = load_module(_root_dir / "scripts/livereduction/eqsans/reduce_EQSANS_live_post_proc.py")
+        livescript.add_to_sys_path = mock_add_to_sys_path
+        livescript.events_file_exists = mock.MagicMock(return_value=False)
+        livescript.copytree = mock.MagicMock()
+        livescript.makedirs = mock.MagicMock()
+        livescript.SaveNexusProcessed = mock_save_nexus
+        livescript.livereduce(simulated_events, publish=False)
+
+        # Verify a temp file was created
+        assert len(temp_files_created) == 1
+        temp_file_path = temp_files_created[0]
+
+        # Verify the temp file is in a temp directory (contains 'livereduce_' prefix)
+        assert "livereduce_" in temp_file_path
+        assert "EQSANS_12345_live.nxs" in temp_file_path
+    finally:
         sys.modules.pop("reduce_EQSANS", None)
 
 

--- a/tests/unit/livereduction/test_reduce_EQSANS_live_post_proc.py
+++ b/tests/unit/livereduction/test_reduce_EQSANS_live_post_proc.py
@@ -138,12 +138,12 @@ def test_livereduce(simulated_events, tmp_path):
         # Verify the temp file path contains the run number
         assert "EQSANS_12345_live.nxs" in save_call_args[1]["Filename"]
 
-        # Verify reduce_events was called with temp_sample_file parameter
+        # Verify reduce_events was called with sample_file parameter
         reduce_events_call = mock_reduce_module.reduce_events
         assert reduce_events_call.called
         call_kwargs = reduce_events_call.call_args[1]
-        assert "temp_sample_file" in call_kwargs
-        assert "EQSANS_12345_live.nxs" in call_kwargs["temp_sample_file"]
+        assert "sample_file" in call_kwargs
+        assert "EQSANS_12345_live.nxs" in call_kwargs["sample_file"]
 
         assert (tmp_path / "EQSANS_12345.html").read_text() == "<report><footer>"
     finally:  # Clean up


### PR DESCRIPTION
## Description of work:

This PR fixes an issue where EQSANS live reduction was failing because it couldn't find a Nexus file on disk. The problem is that during live reduction, Mantid's `LoadLiveData` gives us an `EventWorkspace` in memory, but our reduction pipeline expects to load from a file path. 

The solution saves the EventWorkspace to a temporary processed Nexus file, then passes that file through the normal reduction pipeline. To make this work, I had to teach the loading functions to handle processed Nexus files in addition to the usual event Nexus files.

Here's what changed: The `load_events()` function now has an optional `allow_processed_nexus` parameter that enables a fallback mechanism. It tries to load with `LoadEventNexus` first (the normal path), but if that fails it will fall back to `LoadNexusProcessed`. This fallback only happens when explicitly enabled, so existing autoreduction behavior is completely unchanged.

In the live reduction script, I added code to save the incoming EventWorkspace to a temporary file using `SaveNexusProcessed`, then pass that file path through the reduction pipeline via a new `temp_sample_file` parameter. The temporary file gets automatically cleaned up afterward using Python's `tempfile.TemporaryDirectory` context manager.

I also added tests for the new functionality - unit tests for the processed Nexus loading mechanism and integration tests that verify the full live reduction workflow. The user documentation was updated to explain how live reduction works now, including the technical details about the temporary file approach.

Everything is backward compatible - the default behavior for autoreduction hasn't changed at all since the new parameter defaults to `False`.

**Check all that apply:**
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Added unit tests
- [x] Added integration tests
- [x] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [EWM-15791](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15791)
- Links to related issues or pull requests: N/A

## :warning: Manual test for the reviewer

To test this properly, you'll need access the sshfs mounts with the shared `/SNS/EQSANS/ directory.

The unit tests can run on any machine without the SNS mount:

```bash
# Test the new processed Nexus loading mechanism
pixi run pytest tests/unit/drtsans/test_load_processed_nexus.py -v

# Test the live reduction workflow
pixi run pytest tests/unit/livereduction/test_reduce_EQSANS_live_post_proc.py -v

# Make sure we didn't break existing functionality
pixi run pytest tests/unit/drtsans/test_load.py -v
```

For integration tests, you'll need to be on the analysis cluster or somewhere with SNS access:

```bash
pixi run pytest tests/integration/livereduction/test_reduce_EQSANS_live_post_proc.py -v -m mount_eqsans
```

You should see 11 unit tests pass in total. The integration tests verify the end-to-end workflow including the important round-trip test that saves an EventWorkspace to a processed Nexus file and loads it back using the new fallback mechanism.

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number

```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```

---