### PR TITLE
Refine neutron emission time from the moderator for fast neutrons

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1540,8 +1540,8 @@ packages:
   timestamp: 1765193127016
 - pypi: ./
   name: drtsans
-  version: 1.31.0.dev20260612004016
-  sha256: 9b0a19349ab132c66120437010f8cac16f09dd070c071acdc5745658624830fa
+  version: 1.32.0.dev20260616134216
+  sha256: 6c777be05c2ee44a83e25563c6429e8089c0547f4995d51e870a991de01cc69a
   requires_python: '>=3.12'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
   sha256: a5b51e491fec22bcc1765f5b2c8fff8a97428e9a5a7ee6730095fb9d091b0747

--- a/src/drtsans/tof/eqsans/correct_frame.py
+++ b/src/drtsans/tof/eqsans/correct_frame.py
@@ -431,7 +431,8 @@ def correct_monitor_frame(input_workspace):
 
 # Delayed emission time of a neutron from the moderator as a function of wavelength, in microseconds.
 DELAY_FIT = (
-    "(x < 2.0) ? 0.5*(1280.5-7448.4*x+16509*x^2-17872*x^3+10445*x^4-3169.3*x^5+392.31*x^6) :"
+    "(x < 0.5) ? 9.451719*x :"
+    " (x < 2.0) ? 0.5*(1280.5-7448.4*x+16509*x^2-17872*x^3+10445*x^4-3169.3*x^5+392.31*x^6) :"
     " 0.5*(231.99+6.4797*x-0.5233*x^2+0.0148*x^3)"
 )
 
@@ -443,7 +444,7 @@ def emission_delay(wavelength: float) -> float:
     Parameters
     ----------
     wavelength
-        Wavelength of the neutron, in Angstroms. Must be positive.
+        Wavelength of the neutron, in Angstroms. Must be non-negative.
 
     Returns
     -------
@@ -452,13 +453,23 @@ def emission_delay(wavelength: float) -> float:
     Raises
     ------
     ValueError
-        If ``wavelength`` is not positive, or if the empirical fit yields a negative
+        If ``wavelength`` is negative, or if the empirical fit yields a negative
         delay (which would indicate the input is outside the valid fitted range).
+
+    Notes
+    -----
+    Three piecewise segments are used:
+
+    * 0 ≤ λ < 0.5 Å: linear, anchored at (0, 0) and continuous with the polynomial at 0.5 Å.
+    * 0.5 ≤ λ < 2 Å: degree-6 polynomial empirical fit.
+    * λ ≥ 2 Å: degree-3 polynomial empirical fit.
     """
-    if wavelength <= 0:
-        raise ValueError(f"wavelength must be positive (got {wavelength} Å)")
+    if wavelength < 0:
+        raise ValueError(f"wavelength must be non-negative (got {wavelength} Å)")
     w = wavelength
-    if w < 2.0:
+    if w < 0.5:
+        result = 9.451719 * w
+    elif w < 2.0:
         result = 0.5 * (
             1280.5 - 7448.4 * w + 16509 * w**2 - 17872 * w**3 + 10445 * w**4 - 3169.3 * w**5 + 392.31 * w**6
         )

--- a/tests/unit/drtsans/tof/eqsans/test_correct_frame.py
+++ b/tests/unit/drtsans/tof/eqsans/test_correct_frame.py
@@ -399,15 +399,16 @@ def test_correct_emission_time_30Hz(clean_workspace):
         (5.0, 126.578),
         # small positive λ — polynomial branch must not return a negative delay
         (0.1, "non_negative"),
-        # non-positive wavelengths must raise ValueError
-        (0.0, ValueError),
+        # zero wavelength returns 0 µs (linear segment)
+        (0.0, 0.0),
+        # negative wavelengths must raise ValueError
         (-1.0, ValueError),
         (-0.001, ValueError),
     ],
 )
 def test_emission_delay(wavelength, expected):
     if expected is ValueError:
-        with pytest.raises(ValueError, match="wavelength must be positive"):
+        with pytest.raises(ValueError, match="wavelength must be non-negative"):
             correct_frame.emission_delay(wavelength)
     elif expected == "non_negative":
         assert correct_frame.emission_delay(wavelength) >= 0


### PR DESCRIPTION
## Description of work:

This pull request refines the EQSANS moderator emission delay correction for very short (fast-neutron) wavelengths by adding a dedicated small-λ segment, and aligns unit tests with the updated behavior.

**Check all that apply:**
- [x] Source added/refactored
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [16619](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16619)

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
