### PR TITLE
new skill to create a reduction test from an input JSON

### DIFF
--- a/.agents/skills/explore-defect/SKILL.md
+++ b/.agents/skills/explore-defect/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: explore-defect
+description: Use when the user asks to create a drtsans integration test from, with, or using a JSON file path, especially prompts like "create a test with JSON file /path/to/config.json"; generates a no-assertion exploratory reduction test that loads all files and reduces one configuration.
+---
+
+# Explore Defect
+
+Use this skill to turn a JSON reduction configuration into a focused integration test for
+exploring a defect. The generated test is for reproducing behavior only; it must not assert on
+outputs or compare to expected data.
+
+## Workflow
+
+1. Read the input JSON file and parse it as JSON.
+   - Do not manually transcribe JSON by hand when a parser is available.
+   - Embed the parsed JSON in the generated test as a Python dictionary literal.
+
+2. Determine the instrument from the configuration.
+   - Prefer `instrumentName`.
+   - Treat `EQSANS` as `tests/integration/drtsans/tof/eqsans/`.
+   - Treat `GPSANS` or `CG2` as `tests/integration/drtsans/mono/gpsans/`.
+   - Treat `BIOSANS` or `CG3` as `tests/integration/drtsans/mono/biosans/`.
+   - If the instrument is missing or unsupported, ask the user which supported instrument path to use.
+
+3. Propose the test file path.
+   - Default filename: `test_explore_defect.py`.
+   - Default full path: the instrument directory plus `test_explore_defect.py`.
+   - Show the user the full path and ask them to confirm or provide a different filename.
+   - If the user provides only a filename, keep it in the selected instrument directory.
+   - Use a pytest-compatible filename matching this repository's `python_files = ["test*.py"]` configuration.
+
+4. Propose the output directory amendment.
+   - Default output directory: `/tmp/explore_defect`.
+   - Ask the user to confirm this path or provide another output directory.
+   - Ensure the generated test sets `reduction_input["configuration"]["outputDir"]` to the confirmed path.
+   - If the parsed JSON has no `configuration` dictionary, create one before assigning `outputDir`.
+
+5. Generate the test.
+   - Add imports for the selected instrument:
+     - EQSANS: `from drtsans.tof.eqsans import load_all_files, reduction_parameters, reduce_single_configuration`
+     - GPSANS/CG2: `from drtsans.mono.gpsans import load_all_files, reduction_parameters, reduce_single_configuration`
+     - BIOSANS/CG3: `from drtsans.mono.biosans import load_all_files, reduction_parameters, reduce_single_configuration`
+   - Include `import pytest`.
+   - Mark the test with `@pytest.mark.datarepo`.
+   - Name the function `test_explore_defect`.
+   - The body must contain, in this order:
+     1. `reduction_input = {...}` using the parsed JSON dictionary literal.
+     2. The `configuration.outputDir` amendment.
+     3. `reduction_input = reduction_parameters(parameters_particular=reduction_input, validate=True)`.
+     4. `loaded = load_all_files(reduction_input)`.
+     5. `reduce_single_configuration(loaded, reduction_input)`.
+   - Do not add assertions.
+   - Do not add expected-data checks, gold-file comparisons, or output-file existence checks.
+   - Do not add cleanup unless the user explicitly asks for it.
+
+6. Do not run the generated test.
+   - Do not run integration tests, unit tests, pytest collection, or import checks for the generated file.
+   - If verification is needed, limit it to static inspection of the generated file content.
+
+## Template
+
+Use this structure, selecting the import path for the instrument:
+
+```python
+import pytest
+
+from drtsans.tof.eqsans import load_all_files, reduction_parameters, reduce_single_configuration
+
+
+@pytest.mark.datarepo
+def test_explore_defect():
+    reduction_input = {
+        # parsed JSON dictionary literal
+    }
+    reduction_input.setdefault("configuration", {})
+    reduction_input["configuration"]["outputDir"] = "/tmp/explore_defect"
+    reduction_input = reduction_parameters(parameters_particular=reduction_input, validate=True)
+
+    loaded = load_all_files(reduction_input)
+    reduce_single_configuration(loaded, reduction_input)
+```

--- a/.agents/skills/explore-defect/SKILL.md
+++ b/.agents/skills/explore-defect/SKILL.md
@@ -17,7 +17,7 @@ outputs or compare to expected data.
 
 2. Determine the instrument from the configuration.
    - Prefer `instrumentName`.
-   - Treat `EQSANS` as `tests/integration/drtsans/tof/eqsans/`.
+   - Treat `EQSANS` or `EQ-SANS` as `tests/integration/drtsans/tof/eqsans/`.
    - Treat `GPSANS` or `CG2` as `tests/integration/drtsans/mono/gpsans/`.
    - Treat `BIOSANS` or `CG3` as `tests/integration/drtsans/mono/biosans/`.
    - If the instrument is missing or unsupported, ask the user which supported instrument path to use.

--- a/.agents/skills/pixi-python/SKILL.md
+++ b/.agents/skills/pixi-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pixi-python
-description: Use when working in a Python repository managed by Pixi, including projects with pixi.toml, pixi.lock, .pixi/, or [tool.pixi] sections in pyproject.toml.
+description: Use whenever running Python tooling in a Pixi-managed repository, including python, pytest, ruff, mypy, pip, or similar commands; this environment skill applies alongside task-specific skills when pixi.toml, pixi.lock, .pixi/, or [tool.pixi] sections in pyproject.toml are present.
 ---
 
 # Pixi Python Repositories

--- a/.claude/skills/explore-defect/SKILL.md
+++ b/.claude/skills/explore-defect/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: explore-defect
+description: Use when the user asks to create a drtsans integration test from, with, or using a JSON file path, especially prompts like "create a test with JSON file /path/to/config.json"; generates a no-assertion exploratory reduction test that loads all files and reduces one configuration.
+---
+
+# Explore Defect
+
+Use this skill to turn a JSON reduction configuration into a focused integration test for
+exploring a defect. The generated test is for reproducing behavior only; it must not assert on
+outputs or compare to expected data.
+
+## Workflow
+
+1. Read the input JSON file and parse it as JSON.
+   - Do not manually transcribe JSON by hand when a parser is available.
+   - Embed the parsed JSON in the generated test as a Python dictionary literal.
+
+2. Determine the instrument from the configuration.
+   - Prefer `instrumentName`.
+   - Treat `EQSANS` as `tests/integration/drtsans/tof/eqsans/`.
+   - Treat `GPSANS` or `CG2` as `tests/integration/drtsans/mono/gpsans/`.
+   - Treat `BIOSANS` or `CG3` as `tests/integration/drtsans/mono/biosans/`.
+   - If the instrument is missing or unsupported, ask the user which supported instrument path to use.
+
+3. Propose the test file path.
+   - Default filename: `test_explore_defect.py`.
+   - Default full path: the instrument directory plus `test_explore_defect.py`.
+   - Show the user the full path and ask them to confirm or provide a different filename.
+   - If the user provides only a filename, keep it in the selected instrument directory.
+   - Use a pytest-compatible filename matching this repository's `python_files = ["test*.py"]` configuration.
+
+4. Propose the output directory amendment.
+   - Default output directory: `/tmp/explore_defect`.
+   - Ask the user to confirm this path or provide another output directory.
+   - Ensure the generated test sets `reduction_input["configuration"]["outputDir"]` to the confirmed path.
+   - If the parsed JSON has no `configuration` dictionary, create one before assigning `outputDir`.
+
+5. Generate the test.
+   - Add imports for the selected instrument:
+     - EQSANS: `from drtsans.tof.eqsans import load_all_files, reduction_parameters, reduce_single_configuration`
+     - GPSANS/CG2: `from drtsans.mono.gpsans import load_all_files, reduction_parameters, reduce_single_configuration`
+     - BIOSANS/CG3: `from drtsans.mono.biosans import load_all_files, reduction_parameters, reduce_single_configuration`
+   - Include `import pytest`.
+   - Mark the test with `@pytest.mark.datarepo`.
+   - Name the function `test_explore_defect`.
+   - The body must contain, in this order:
+     1. `reduction_input = {...}` using the parsed JSON dictionary literal.
+     2. The `configuration.outputDir` amendment.
+     3. `reduction_input = reduction_parameters(parameters_particular=reduction_input, validate=True)`.
+     4. `loaded = load_all_files(reduction_input)`.
+     5. `reduce_single_configuration(loaded, reduction_input)`.
+   - Do not add assertions.
+   - Do not add expected-data checks, gold-file comparisons, or output-file existence checks.
+   - Do not add cleanup unless the user explicitly asks for it.
+
+6. Do not run the generated test.
+   - Do not run integration tests, unit tests, pytest collection, or import checks for the generated file.
+   - If verification is needed, limit it to static inspection of the generated file content.
+
+## Template
+
+Use this structure, selecting the import path for the instrument:
+
+```python
+import pytest
+
+from drtsans.tof.eqsans import load_all_files, reduction_parameters, reduce_single_configuration
+
+
+@pytest.mark.datarepo
+def test_explore_defect():
+    reduction_input = {
+        # parsed JSON dictionary literal
+    }
+    reduction_input.setdefault("configuration", {})
+    reduction_input["configuration"]["outputDir"] = "/tmp/explore_defect"
+    reduction_input = reduction_parameters(parameters_particular=reduction_input, validate=True)
+
+    loaded = load_all_files(reduction_input)
+    reduce_single_configuration(loaded, reduction_input)
+```

--- a/.claude/skills/explore-defect/SKILL.md
+++ b/.claude/skills/explore-defect/SKILL.md
@@ -17,7 +17,7 @@ outputs or compare to expected data.
 
 2. Determine the instrument from the configuration.
    - Prefer `instrumentName`.
-   - Treat `EQSANS` as `tests/integration/drtsans/tof/eqsans/`.
+   - Treat `EQSANS` or `EQ-SANS` as `tests/integration/drtsans/tof/eqsans/`.
    - Treat `GPSANS` or `CG2` as `tests/integration/drtsans/mono/gpsans/`.
    - Treat `BIOSANS` or `CG3` as `tests/integration/drtsans/mono/biosans/`.
    - If the instrument is missing or unsupported, ask the user which supported instrument path to use.

--- a/.claude/skills/pixi-python/SKILL.md
+++ b/.claude/skills/pixi-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pixi-python
-description: Use when working in a Python repository managed by Pixi, including projects with pixi.toml, pixi.lock, .pixi/, or [tool.pixi] sections in pyproject.toml.
+description: Use whenever running Python tooling in a Pixi-managed repository, including python, pytest, ruff, mypy, pip, or similar commands; this environment skill applies alongside task-specific skills when pixi.toml, pixi.lock, .pixi/, or [tool.pixi] sections in pyproject.toml are present.
 ---
 
 # Pixi Python Repositories

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@
 
 ## Technology Stack
 
+- **pixi-python**: load the pixi-python skill when attempting to run any Python-related tool, including python, pytest, ruff, mypy, pip
 - **Mantid**: use `mantid.simpleapi` for algorithms, `mantid.kernel` for logging/configuration, and `mantid.api` for workspace types.
 - **Testing**: pytest with pytest-cov, pytest-qt, pytest-mock, pytest-xvfb, and pytest-xdist.
 - **Linting/formatting**: ruff, configured in `pyproject.toml`.


### PR DESCRIPTION
## Description of work:

Skill `explore-defect` facilitates the generation of a vanilla reduction test for a given input `*.json` configuration. It's meant to cover the scenario where the instrument scientist reports a possible defect and attaches a JSON file. The reduction test then allows one to begin exploring the issue.

**Check all that apply:**
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

## :warning: Manual test for the reviewer
Download [pvb5poss-40c-SO-4_4m_conf1.json](https://github.com/user-attachments/files/29210361/pvb5poss-40c-SO-4_4m_conf1.json) under `/tmp`. Then in Claude or Codex, enter the prompt:
```
Create a reduction test for input configuration /tmp/pvb5poss-40c-SO-4_4m_conf1.json
```
The agent will ask you to confirm the name of the test and the output directory. The test will contain:
- the JSON file as a dictionary
- amend the output directory with the one given
- function to load all files
- function to reduce a single configuration


## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
