### PR TITLE
omit `type` for Python ignore rule

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -2,17 +2,16 @@ ignore:
   - package:
       name: python
       version: "3.12.*"
-      type: binary
-    reason: "Python 3.12.x binary detection; vulnerabilities tracked upstream."
+    reason: "version pinned by Mantid 6.15.*"
 
   - package:
       name: gstreamer
       version: "1.26.11"
       type: conda
-    reason: "gstreamer 1.26.11 has multiple CVEs with no fix available yet; ignored until conda-forge ships a patched version."
+    reason: "version pinned by Mantid 6.15.*"
 
   - package:
       name: pyo3
       version: "0.28.3"
       type: rust-crate
-    reason: "Transitive pyo3 vulnerability reported via rpds; awaiting dependency update to pyo3 >= 0.29.0."
+    reason: "version pinned by Mantid 6.15.*"


### PR DESCRIPTION
## Description of work:

.grype.yaml updates the reason text for three existing ignore entries: python@3.12.*, gstreamer@1.26.11 (conda), and pyo3@0.28.3 (rust-crate). The package names, versions, and types are unchanged.

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
