### PR TITLE
Eqsans autoreduction

### DIFF
--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
-"""Autoreduction script for EQSANS"""
+"""
+EDIT THIS FILE ONLY IN THE drtsans REPOSITORY (https://github.com/neutrons/drtsans)
+
+To make changes to this file:
+- open a feature branch in the `drtsans` repository
+- make your changes and submit a pull request for review.
+- after the pull request is merged, deploy the updated script in /SNS/EQSANS/shared/autoreduce
+"""
 
 import argparse
 from copy import deepcopy
@@ -49,7 +56,7 @@ except ImportError:
 # silently ignore all types of numerical errors (like divide by zero, overflow, etc.)
 np.seterr(all="ignore")
 warnings.filterwarnings("ignore", module="numpy")
-CONDA_ENV = "sans-qa"
+CONDA_ENV = "sans_qa"
 
 LOG_NAME = "autoreduce"
 AUTOREDUCE_DIR = "/SNS/EQSANS/shared/autoreduce"
@@ -430,7 +437,7 @@ def reduce_sample(
 
     # Generate GPR analysis plots
     if GPR_AVAILABLE:
-        logger.info("reduce_sample: generating GPR analysis plots")
+        logger.info("reduce_sample: generating Gaussian Process Regression (GPR) analysis plots")
         gpr_report = autoreduction_plots(
             reduction_output=output,
             output_dir=output_dir,
@@ -439,6 +446,8 @@ def reduce_sample(
         )
         if gpr_report:
             report += gpr_report + "<hr>\n"
+    else:
+        logger.warning("Gaussian Process Regression (GPR) analysis plots not available")
 
     # Save the input reduction options
     logger.info("reduce_sample: saving final input reduction options to JSON file")
@@ -573,7 +582,7 @@ def reduce_events(
         else:
             report += reduce_non_sample(events)
     except Exception:
-        logger.error("Reduction failed")
+        logger.error("Reduction failed", exc_info=True)
 
     # If reduction failed, include error log messages and traceback in the HTML report
     error_messages = error_buffer.getvalue()

--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -18,6 +18,7 @@ from collections import namedtuple
 import os
 import re
 import requests
+import stat
 import sys
 import time
 from typing import Union
@@ -56,7 +57,7 @@ except ImportError:
 # silently ignore all types of numerical errors (like divide by zero, overflow, etc.)
 np.seterr(all="ignore")
 warnings.filterwarnings("ignore", module="numpy")
-CONDA_ENV = "sans_qa"
+CONDA_ENV = "sans_dev"
 
 LOG_NAME = "autoreduce"
 AUTOREDUCE_DIR = "/SNS/EQSANS/shared/autoreduce"
@@ -642,6 +643,9 @@ def autoreduce(args: argparse.Namespace):
     if output_dir == AUTOREDUCE_IPTS_DIR.format(ipts=ipts):  # e.g. /SNS/EQSANS/IPTS-12345/shared/autoreduce/
         output_dir = os.path.join(args.outdir, run)  # e.g. /SNS/EQSANS/IPTS-12345/shared/autoreduce/198434/
     os.makedirs(output_dir, exist_ok=True)
+    # Give write access to group so that the autoreduction service can overwrite any output files generated
+    # by one of the developers when manually running the reduction, for instance for debugging purposes
+    os.chmod(output_dir, os.stat(output_dir).st_mode | stat.S_IWGRP)
 
     # instantiate the logging context
     run_number = str(events.getRunNumber())  # e.g. "105584"

--- a/tests/unit/autoreduction/test_reduce_EQSANS.py
+++ b/tests/unit/autoreduction/test_reduce_EQSANS.py
@@ -71,7 +71,7 @@ def test_constants_values():
     assert reduce_EQSANS.TUBES_PER_EIGHTPACK == 8
     assert reduce_EQSANS.TUBES_IN_DETECTOR1 == 192
     assert reduce_EQSANS.PIXELS_PER_TUBE == 256
-    assert reduce_EQSANS.CONDA_ENV in ("sans", "sans-qa", "sans-dev")
+    assert reduce_EQSANS.CONDA_ENV in ("sans", "sans_qa", "sans_dev")
 
 
 def test_upload_report():


### PR DESCRIPTION
## Description of work:
Updates the EQSANS autoreduction entrypoint script (`scripts/autoreduction/reduce_EQSANS.py`) to improve operational behavior and clarity when running reductions and generating reports on the EQSANS shared autoreduction infrastructure.

**Changes:**
- Added an explicit “edit/deploy” header comment to guide where changes to this production script should be made.
- Improved logging: clearer GPR log message, warning when GPR is unavailable, and exception tracebacks on reduction failure.
- Adjusted runtime behavior: changed `CONDA_ENV` value and added a chmod step to make the output directory group-writable.

**Check all that apply:**
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [16709](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16709)

## :warning: Manual test for the reviewer
Go to https://monitor.sns.gov/report/eqsans/185943/ and click in the `reduction` button to verify the new
autoreduction script works.

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
