### PR TITLE
Polarization conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,26 @@
 @.github/copilot-instructions.md
+
+## Personal Codex Context
+
+At the start of work in this repository, inspect non-sensitive auxiliary Codex
+context under `~/.codex/` when filesystem permissions allow it.
+
+Prefer these locations:
+
+- `~/.codex/rules/*.rules`
+- `~/.codex/config.toml`
+- `~/.codex/skills/*/SKILL.md`
+- `~/.codex/agents/**`
+- `~/.codex/plugins/**/skills/**/SKILL.md`
+
+Do not read or summarize sensitive runtime state unless the user explicitly
+asks:
+
+- `~/.codex/auth.json`
+- `~/.codex/history.jsonl`
+- `~/.codex/sessions/**`
+- `~/.codex/log/**`
+- `~/.codex/*.sqlite*`
+- `~/.codex/shell_snapshots/**`
+
+Summarize which auxiliary files were loaded and apply only instructions relevant to the current task.

--- a/docs/user/polarization.rst
+++ b/docs/user/polarization.rst
@@ -197,7 +197,7 @@ Full polarization - polarized beam with polarization analysis
 
 When full polarization is employed, a :math:`^3`\ He spin filter is inserted between the sample and
 the detector. The filter is also a spin flipper that rotates the spin by 0° or 180° and the
-polarizations of the two states of the :math:`^3`\ He spin filter are denoted by :math:`A^0(\lambda)`
+flipping ratios of the two states of the :math:`^3`\ He spin filter are denoted by :math:`A^0(\lambda)`
 and :math:`A^{\pi}(\lambda)`. The 0° state is assumed to preferentially pass the spin-up state, but
 the software must allow for the reverse to be true. The four possible flipper states are related to
 the four spin states through Equations :eq:`full-s-off-zero` through :eq:`full-s-on-pi`.
@@ -413,3 +413,25 @@ During reduction, we'll use Mantid's filtering capabilities to discount events c
 .. figure:: media/polarization_2.png
    :alt: Relation between flipper and veto logs
    :width: 800px
+
+
+drtsans Implementation Notes
+----------------------------
+
+The implementation of polarization corrections in drtsans is based on the equations presented above.
+However, polarizations :math:`P(\lambda)` are used instead of flipping ratios :math:`R(\lambda)`
+because polarizations are bounded between -1 and 1, while flipping ratios are unbounded.
+The relationship between the two is given by:
+
+.. math::
+    P(\lambda) = \frac{R(\lambda) - 1}{R(\lambda) + 1}
+
+Using polarizations avoids numerical issues when the flipping ratio is very large.
+
+The input configuration (JSON file) allows for the specification of the polarizer's polarization
+and the efficiency of the flipper.
+It also allows for the specification of analyzer's polarizations for the two states of the analyzer.
+These values can be specified as either a single value or as a string expression representing
+a wavelength-dependent function :math:`f(x)`.
+See the "polarization" entry in the :doc:`reduction parameters reference </drtsans/reduction_parameters>`
+for the full JSON configuration schema.

--- a/pixi.lock
+++ b/pixi.lock
@@ -187,6 +187,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.7.1-hd3da7ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.88.1-hd810c12_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.8-hbf7d49c_1.conda
@@ -292,6 +294,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.4-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.4-py312hd3ec401_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.4-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
@@ -402,6 +406,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
@@ -455,6 +460,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpld3-0.5.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -525,6 +531,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinydb-4.8.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
@@ -1257,6 +1264,37 @@ packages:
   purls: []
   size: 236955
   timestamp: 1778508800134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
+  md5: c94a5994ef49749880a8139cf9afcbe1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
+  run_exports:
+    weak:
+    - gmp >=6.3.0,<7.0a0
+  size: 460055
+  timestamp: 1718980856608
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+  sha256: 6fbdd686d04a0d8c48efe92795137d3bba55a4325acd7931978fd8ea5e24684d
+  md5: fedbe80d864debab03541e1b447fc12a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls:
+  - pkg:pypi/gmpy2?source=hash-mapping
+  run_exports: {}
+  size: 253171
+  timestamp: 1773245116314
 - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
   sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
   md5: cf09e9fc938518e91d0706572cadf17a
@@ -2751,6 +2789,37 @@ packages:
   - pkg:pypi/matplotlib?source=hash-mapping
   size: 7893167
   timestamp: 1734120409482
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+  sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
+  md5: 770d00bf57b5599c4544d61b61d8c6c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  - mpfr >=4.2.2,<5.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - mpc >=1.4.0,<2.0a0
+  size: 100245
+  timestamp: 1774472435333
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+  sha256: 8690f550a780f75d9c47f7ffc15f5ff1c149d36ac17208e50eda101ca16611b9
+  md5: 85ce2ffa51ab21da5efa4a9edc5946aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - mpfr >=4.2.2,<5.0a0
+  size: 730422
+  timestamp: 1773413915171
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
   sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   md5: c7f302fd11eeb0987a6a5e1f3aed6a21
@@ -3680,7 +3749,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/secretstorage?source=compressed-mapping
+  - pkg:pypi/secretstorage?source=hash-mapping
   size: 33068
   timestamp: 1780858489957
 - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.5.0-py314hdafbbf9_0.conda
@@ -4655,6 +4724,18 @@ packages:
   - pkg:pypi/conda-package-streaming?source=hash-mapping
   size: 23954
   timestamp: 1781293054998
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+  noarch: generic
+  sha256: d3e9bbd7340199527f28bbacf947702368f31de60c433a16446767d3c6aaf6fe
+  md5: f54c1ffb8ecedb85a8b7fcde3a187212
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi * *_cp312
+  license: Python-2.0
+  purls: []
+  run_exports: {}
+  size: 46463
+  timestamp: 1772728929620
 - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
   sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
   md5: 4c2a8fef270f6c69591889b93f9f55c1
@@ -5319,6 +5400,18 @@ packages:
   - pkg:pypi/mpld3?source=hash-mapping
   size: 176172
   timestamp: 1734638008466
+- conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+  sha256: 5bbf2f8179ec43d34d67ca8e4989d216c1bdb4b749fe6cb40e86ebf88c1b5300
+  md5: 2e81b32b805f406d23ba61938a184081
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpmath?source=hash-mapping
+  run_exports: {}
+  size: 464918
+  timestamp: 1773662068273
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -6252,6 +6345,22 @@ packages:
   - pkg:pypi/stack-data?source=hash-mapping
   size: 26988
   timestamp: 1733569565672
+- conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+  sha256: 1c8057e6875eba958aa8b3c1a072dc9a75d013f209c26fd8125a5ebd3abbec0c
+  md5: 32d866e43b25275f61566b9391ccb7b5
+  depends:
+  - __unix
+  - cpython
+  - gmpy2 >=2.0.8
+  - mpmath >=1.1.0,<1.5
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/sympy?source=hash-mapping
+  run_exports: {}
+  size: 4661767
+  timestamp: 1771952371059
 - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
   sha256: 6016672e0e72c4cf23c0cf7b1986283bd86a9c17e8d319212d78d8e9ae42fdfd
   md5: 9d64911b31d57ca443e9f1e36b04385f
@@ -6443,7 +6552,7 @@ packages:
   - python
   license: MIT
   purls:
-  - pkg:pypi/vcs-versioning?source=compressed-mapping
+  - pkg:pypi/vcs-versioning?source=hash-mapping
   size: 82624
   timestamp: 1782297377827
 - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,9 @@ pyqt = ">=5,<6"
 qtpy = ">=2.4.3"
 matplotlib = "*"
 requests = "*"
-tinydb = "*"
 sortedcontainers = "*"
+sympy = "*"
+tinydb = "*"
 
 [tool.pixi.pypi-dependencies]
 drtsans = { path = ".", editable = true }
@@ -130,8 +131,9 @@ pyqt = ">=5,<6"
 qtpy = ">=2.4.3"
 matplotlib = "*"
 requests = "*"
-tinydb = "*"
 sortedcontainers = "*"
+sympy = "*"
+tinydb = "*"
 
 # Environments and features
 

--- a/scripts/common_utils.py
+++ b/scripts/common_utils.py
@@ -2,7 +2,6 @@
 
 import os
 import numpy as np
-import matplotlib.pyplot as plt
 import drtsans  # noqa E402
 from mantid.simpleapi import mtd, LoadEmptyInstrument, MaskBTP, ExtractMask
 from drtsans.iq import (
@@ -114,11 +113,9 @@ def get_Iq(
     save_ascii_binned_1D(filename, "I(Q)", iq_output)
 
     filename = os.path.join(output_dir, output_file + label + "_Iq.png")
-    plot_IQmod([iq_output], filename, backend="mpl")
-    plt.clf()
+    plot_IQmod([iq_output], filename, backend="mpl", close_figures=True)
     filename = os.path.join(output_dir, output_file + label + "_Iq.json")
-    plot_IQmod([iq_output], filename, backend="d3")
-    plt.close()
+    plot_IQmod([iq_output], filename, backend="d3", close_figures=True)
     return iq_output
 
 
@@ -143,10 +140,8 @@ def get_Iqxqy(q_data, output_dir, output_file, label="", weighting=False, nbins=
     save_ascii_binned_2D(filename, "I(Qx,Qy)", iq_output)
 
     filename = os.path.join(output_dir, output_file + label + "_Iqxqy.png")
-    plot_IQazimuthal(iq_output, filename, backend="mpl")
-    plt.clf()
+    plot_IQazimuthal(iq_output, filename, backend="mpl", close_figures=True)
     filename = os.path.join(output_dir, output_file + label + "_Iqxqy.json")
-    plot_IQazimuthal(iq_output, filename, backend="d3")
-    plt.close()
+    plot_IQazimuthal(iq_output, filename, backend="d3", close_figures=True)
 
     return iq_output

--- a/src/drtsans/configuration/schema/BIOSANS.json
+++ b/src/drtsans/configuration/schema/BIOSANS.json
@@ -91,11 +91,11 @@
         "QbinType":             {"$ref":  "common.json#/configuration/QbinType"},
         "numMainQBins": {
           "$ref":  "common.json#/configuration/numQBins",
-          "evaluateCondition": "('{#configuration/QbinType}' == 'linear' and {this} is not None) or ('{#configuration/QbinType}' == 'log' and (({this} is None) ^ ({#configuration/LogQBinsPerDecadeMain} is None)))"
+          "evaluateCondition": "('{#configuration/QbinType}' == 'linear' and {this} != None) or ('{#configuration/QbinType}' == 'log' and (({this} == None) ^ ({#configuration/LogQBinsPerDecadeMain} == None)))"
         },
         "numWingQBins": {
           "$ref":  "common.json#/configuration/numQBins",
-          "evaluateCondition": "('{#configuration/QbinType}' == 'linear' and {this} is not None) or ('{#configuration/QbinType}' == 'log' and (({this} is None) ^ ({#configuration/LogQBinsPerDecadeWing} is None)))"
+          "evaluateCondition": "('{#configuration/QbinType}' == 'linear' and {this} != None) or ('{#configuration/QbinType}' == 'log' and (({this} == None) ^ ({#configuration/LogQBinsPerDecadeWing} == None)))"
         },
         "numMidrangeQBins": {
           "$ref":  "common.json#/configuration/numQBins"

--- a/src/drtsans/configuration/schema/EQSANS.json
+++ b/src/drtsans/configuration/schema/EQSANS.json
@@ -180,7 +180,7 @@
         "QbinType": {
           "$ref": "common.json#/configuration/QbinType",
           "default": "log",
-          "evaluateCondition": "('{this}' == 'linear' and {#configuration/numQBins} is not None) or ('{this}' == 'log' and (({#configuration/numQBins} is None) ^ ({#configuration/LogQBinsPerDecade} is None)))"
+          "evaluateCondition": "('{this}' == 'linear' and {#configuration/numQBins} != None) or ('{this}' == 'log' and (({#configuration/numQBins} == None) ^ ({#configuration/LogQBinsPerDecade} == None)))"
         },
         "numQBins": { "$ref": "common.json#/configuration/numQBins" },
         "LogQBinsPerDecade": { "$ref": "common.json#/configuration/LogQBinsPerDecade" },

--- a/src/drtsans/configuration/schema/GPSANS.json
+++ b/src/drtsans/configuration/schema/GPSANS.json
@@ -115,12 +115,13 @@
               "type": "object",
               "properties": {
                 "polarization": {
-                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
-                  "description": "wavelength-dependent polarization function of the incident neutron (wavelength in Å). Default is '1'"
+                  "$ref": "common.json#/definitions/polarizationPropertyPolarization",
+                  "default": "1",
+                  "description": "wavelength-dependent polarization of the incident neutron (in Å) expressed as f(x) or a float in [-1, 1]. Default is '1'."
                 },
                 "efficiency": {
-                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
-                  "description": "wavelength-dependent efficiency function of the spin flipper (wavelength in Å). Default is '1'"
+                  "$ref": "common.json#/definitions/polarizationPropertyEfficiency",
+                  "description": "wavelength-dependent efficiency of the spin flipper (in Å) expressed as f(x) or a float in [0, 1]. Default is '1'."
                 }
               }
             },
@@ -128,12 +129,14 @@
               "type": "object",
               "properties": {
                 "polarizationZero": {
-                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
-                  "description": "wavelength-dependent polarization function of the 3He spin filter in its 0° state (wavelength in Å). Default is '1'"
+                  "$ref": "common.json#/definitions/polarizationPropertyPolarization",
+                  "default": "1",
+                  "description": "wavelength-dependent polarization of the 3He spin filter in its 0° state (in Å) expressed as f(x) or a float in [-1, 1]. Default is '1'."
                 },
                 "polarizationPi": {
-                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
-                  "description": "wavelength-dependent polarization function of the 3He spin filter in its π° state (wavelength in Å). Default is '1'"
+                  "$ref": "common.json#/definitions/polarizationPropertyPolarization",
+                  "default": "-1",
+                  "description": "wavelength-dependent polarization function of the 3He spin filter in its π° state (in Å) expressed as f(x) or a float in [-1, 1]. Default is '-1'."
                 }
               }
             }

--- a/src/drtsans/configuration/schema/GPSANS.json
+++ b/src/drtsans/configuration/schema/GPSANS.json
@@ -106,7 +106,40 @@
         "smearingPixelSizeY": {"$ref":  "common.json#/configuration/smearingPixelSizeY"},
         "useSubpixels":      {"$ref":  "common.json#/configuration/useSubpixels", "default": true},
         "subpixelsX":        {"$ref":  "common.json#/configuration/subpixelsX", "default": 5},
-        "subpixelsY":        {"$ref":  "common.json#/configuration/subpixelsY", "default": 5}
+        "subpixelsY":        {"$ref":  "common.json#/configuration/subpixelsY", "default": 5},
+
+        "polarization": {
+          "type": "object",
+          "properties": {
+            "polarizer": {
+              "type": "object",
+              "properties": {
+                "polarization": {
+                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
+                  "description": "wavelength-dependent polarization function of the incident neutron (wavelength in Å). Default is '1'"
+                },
+                "efficiency": {
+                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
+                  "description": "wavelength-dependent efficiency function of the spin flipper (wavelength in Å). Default is '1'"
+                }
+              }
+            },
+            "analyzer": {
+              "type": "object",
+              "properties": {
+                "polarizationZero": {
+                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
+                  "description": "wavelength-dependent polarization function of the 3He spin filter in its 0° state (wavelength in Å). Default is '1'"
+                },
+                "polarizationPi": {
+                  "$ref": "common.json#/definitions/polarizationDeviceProperty",
+                  "description": "wavelength-dependent polarization function of the 3He spin filter in its π° state (wavelength in Å). Default is '1'"
+                }
+              }
+            }
+          }
+        }
+
       },
       "required": ["outputDir", "wavelength", "wavelengthSpread", "useTimeSlice", "timeSliceInterval",
         "timeSliceOffset", "timeSlicePeriod", "useLogSlice", "logSliceName", "logSliceInterval",
@@ -121,7 +154,7 @@
         "autoWedgeQmin", "autoWedgeQmax", "autoWedgeQdelta", "autoWedgeAzimuthalDelta",
         "autoWedgePeakWidth", "autoWedgeBackgroundWidth", "autoWedgeSignalToNoiseMin", "AnnularAngleBin",
         "Qmin", "Qmax", "useErrorWeighting", "smearingPixelSizeX", "smearingPixelSizeY",
-        "useSubpixels", "subpixelsX", "subpixelsY"]
+        "useSubpixels", "subpixelsX", "subpixelsY", "polarization"]
     }
   },
   "required": ["schemaStamp", "instrumentName", "iptsNumber", "dataDirectories", "sample", "background",

--- a/src/drtsans/configuration/schema/GPSANS.json
+++ b/src/drtsans/configuration/schema/GPSANS.json
@@ -80,7 +80,7 @@
         "QbinType": {
           "$ref":  "common.json#/configuration/QbinType",
           "default": "log",
-          "evaluateCondition": "('{this}' == 'linear' and {#configuration/numQBins} is not None) or ('{this}' == 'log' and (({#configuration/numQBins} is None) ^ ({#configuration/LogQBinsPerDecade} is None)))"
+          "evaluateCondition": "('{this}' == 'linear' and {#configuration/numQBins} != None) or ('{this}' == 'log' and (({#configuration/numQBins} == None) ^ ({#configuration/LogQBinsPerDecade} == None)))"
         },
         "numQBins":                {"$ref":  "common.json#/configuration/numQBins"},
         "LogQBinsPerDecade":       {"$ref":  "common.json#/configuration/LogQBinsPerDecade"},

--- a/src/drtsans/configuration/schema/common.json
+++ b/src/drtsans/configuration/schema/common.json
@@ -142,6 +142,15 @@
           "maxItems": 2
         }
       ]
+    },
+    "polarizationDeviceProperty": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "number"}
+      ],
+      "default": "1",
+      "examples": ["0.95", "0.95-0.01*(x-16)", 0.95],
+      "description": "Wavelength-dependent formula expressed as a string in x (wavelength in Å), or a float. Default '1' means no correction."
     }
   },
 

--- a/src/drtsans/configuration/schema/common.json
+++ b/src/drtsans/configuration/schema/common.json
@@ -143,14 +143,20 @@
         }
       ]
     },
-    "polarizationDeviceProperty": {
+    "polarizationPropertyPolarization": {
       "anyOf": [
         {"type": "string"},
-        {"type": "number"}
+        {"type": "number", "minimum": -1, "maximum": 1}
+      ],
+      "examples": ["0.95", "-0.95","0.95-0.01*(x-16)", 0.95, -0.95]
+    },
+    "polarizationPropertyEfficiency": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "number", "minimum": 0, "maximum": 1}
       ],
       "default": "1",
-      "examples": ["0.95", "0.95-0.01*(x-16)", 0.95],
-      "description": "Wavelength-dependent formula expressed as a string in x (wavelength in Å), or a float. Default '1' means no correction."
+      "examples": ["0.95", "0.95-0.01*(x-16)", 0.95]
     }
   },
 

--- a/src/drtsans/filterevents/spinfilter.py
+++ b/src/drtsans/filterevents/spinfilter.py
@@ -14,6 +14,7 @@ from mantid.simpleapi import CreateEmptyTableWorkspace, GenerateEventsFilter, lo
 
 from drtsans.filterevents.basefilter import FilterStrategy
 from drtsans.polarization import (
+    PolarizationCrossSection,
     PV_POLARIZER_FLIPPER,
     PV_ANALYZER_FLIPPER,
     PV_POLARIZER,
@@ -116,7 +117,7 @@ def create_table(
         A table with columns:
         - 'start' (float): Start time of the interval in seconds
         - 'stop' (float): Stop time of the interval in seconds
-        - 'target' (str): Cross-section label (e.g., 'On_Off', 'Off_On')
+        - 'target' (str): Cross-section label (e.g., 'on_off', 'off_on')
 
     Notes
     -----
@@ -125,10 +126,14 @@ def create_table(
     - Neither polarizer nor analyzer veto is active
 
     Cross-section labels follow the format '{polarizer_state}_{analyzer_state}'
-    where each state is either 'On' or 'Off'.
+    where each state is either 'on' or 'off'. If only one polarization device
+    is active, the label contains only that device state.
 
     Time intervals before start_time are discarded or truncated.
     """
+    if has_analyzer and not has_polarizer:
+        raise ValueError("Analyzer polarization requires an active polarizer.")
+
     split_table_ws = SplittersWorkspace()  # Table-like object with columns "start", "stop", and "workspacegroup"
     mtd.addOrReplace(output_splitter_workspace, split_table_ws)
     info_table_ws = CreateEmptyTableWorkspace(OutputWorkspace=output_info_workspace)
@@ -149,7 +154,13 @@ def create_table(
 
     def _add_cross_section_row(start_ns: int, stop_ns: int):
         """Add a row to the table workspace for the current state."""
-        xs_label = "%s_%s" % ("On" if current_state[POLARIZER] else "Off", "On" if current_state[ANALYZER] else "Off")
+        state_labels = []
+        on, off = str(PolarizationCrossSection.ON), str(PolarizationCrossSection.OFF)
+        if has_polarizer:
+            state_labels.append(on if current_state[POLARIZER] else off)
+            if has_analyzer:
+                state_labels.append(on if current_state[ANALYZER] else off)
+        xs_label = "_".join(state_labels)
         start = int(start_ns - start_time)
         stop = stop_ns - start_time
 
@@ -241,12 +252,13 @@ class SpinFilter(FilterStrategy):
     rather than using Mantid's standard time or log interval filters. This allows
     for complex state combinations and veto handling.
 
-    Cross-section workspaces are labeled as '{polarizer}_{analyzer}' where each
-    is either 'On' or 'Off'. For example:
-    - 'On_On': Both polarizer and analyzer ON
-    - 'On_Off': Polarizer ON, analyzer OFF
-    - 'Off_On': Polarizer OFF, analyzer ON
-    - 'Off_Off': Both polarizer and analyzer OFF
+    Cross-section workspaces are labeled with lowercase device states. Half
+    polarization uses one state, ``"off"`` or ``"on"``. Full polarization uses
+    ``"{polarizer}_{analyzer}"`` labels, for example:
+    - ``"on_on"``: both polarizer and analyzer ON
+    - ``"on_off"``: polarizer ON, analyzer OFF
+    - ``"off_on"``: polarizer OFF, analyzer ON
+    - ``"off_off"``: both polarizer and analyzer OFF
     """
 
     def __init__(
@@ -498,7 +510,7 @@ class SpinFilter(FilterStrategy):
             The workspace group (or its name) containing the filtered cross-sections
         """
         for _, samplelogs, cross_section in self._inject_common_metadata(workspace):
-            samplelogs.insert("slice_parameter", "polarization.cross_section")
-            samplelogs.insert("polarization.cross_section", cross_section)
+            samplelogs.insert("slice_parameter", PolarizationCrossSection.logname)
+            samplelogs.insert(PolarizationCrossSection.logname, cross_section)
             samplelogs.insert("polarization.active_polarizer", int(self._active_polarizer))
             samplelogs.insert("polarization.active_analyzer", int(self._active_analyzer))

--- a/src/drtsans/mono/biosans/api.py
+++ b/src/drtsans/mono/biosans/api.py
@@ -17,7 +17,6 @@ from mantid.simpleapi import (
     RemoveWorkspaceHistory,
 )
 from matplotlib.colors import LogNorm
-import matplotlib.pyplot as plt
 
 import drtsans
 from drtsans import getWedgeSelection, subtract_background, NoDataProcessedError
@@ -1093,6 +1092,7 @@ def plot_reduction_output(
     reduction_input: dict,
     loglog: bool = True,
     imshow_kwargs: dict = {},
+    close_figures: bool = True,
 ):
     """
     Generate reduction plot per slice per detector.
@@ -1107,6 +1107,8 @@ def plot_reduction_output(
         Whether to plot in loglog scale, by default True.
     imshow_kwargs:
         Keyword arguments to pass to imshow, by default {}.
+    close_figures:
+        Close pyplot-managed figures after saving, by default True.
     """
     reduction_config = reduction_input["configuration"]
     output_dir = reduction_config["outputDir"]
@@ -1155,8 +1157,8 @@ def plot_reduction_output(
             symmetric_wedges=symmetric_wedges,
             qmin=qmin_main,
             qmax=qmax_main,
+            close_figures=close_figures,
         )
-        plt.clf()
 
         # wing detector
         filename = os.path.join(output_dir, "2D", f"{outputFilename}{output_suffix}_2D_wing.png")
@@ -1170,8 +1172,8 @@ def plot_reduction_output(
             symmetric_wedges=symmetric_wedges,
             qmin=qmin_wing,
             qmax=qmax_wing,
+            close_figures=close_figures,
         )
-        plt.clf()
 
         # special case for mid-range detector
         if has_midrange_detector:
@@ -1186,8 +1188,8 @@ def plot_reduction_output(
                 symmetric_wedges=symmetric_wedges,
                 qmin=qmin_midrange,
                 qmax=qmax_midrange,
+                close_figures=close_figures,
             )
-            plt.clf()
 
         for j in range(len(out.I1D_main)):
             add_suffix = ""
@@ -1201,6 +1203,7 @@ def plot_reduction_output(
                     log_scale=loglog,
                     backend="mpl",
                     errorbar_kwargs={"label": "main,wing,midrange,both"},
+                    close_figures=close_figures,
                 )
             else:
                 plot_i1d(
@@ -1209,10 +1212,8 @@ def plot_reduction_output(
                     log_scale=loglog,
                     backend="mpl",
                     errorbar_kwargs={"label": "main,wing,both"},
+                    close_figures=close_figures,
                 )
-            plt.clf()
-
-    plt.close()
 
     # allow overwrite
     allow_overwrite(os.path.join(output_dir, "1D"))

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -13,7 +13,6 @@ from mantid.simpleapi import (
     mtd,
     MaskDetectors,
     MoveInstrumentComponent,
-    RenameWorkspace,
     SaveNexusProcessed,
     RemoveWorkspaceHistory,
 )
@@ -1315,7 +1314,7 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
                 mask_panel=mask_panel,
                 solid_angle=solid_angle,
                 sensitivity_workspace=loaded_ws.sensitivity,
-                output_workspace="processed_data_main",
+                output_workspace=f"processed_data_main{output_suffix}",
                 output_suffix=output_suffix,
                 thickness=thickness,
                 absolute_scale_method=absolute_scale_method,
@@ -1332,13 +1331,6 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
                 continue
             else:
                 raise
-        processed_workspace_name = f"processed_data_main{output_suffix}"
-        # Single-slice reductions already use this name; Mantid rejects renaming a workspace to itself.
-        if str(processed_data_main) != processed_workspace_name:
-            processed_data_main = RenameWorkspace(
-                InputWorkspace=processed_data_main,
-                OutputWorkspace=processed_workspace_name,
-            )
         processed_samples.append((processed_data_main, name, output_suffix))
 
     if not processed_samples:

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -1333,6 +1333,7 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
             else:
                 raise
         processed_workspace_name = f"processed_data_main{output_suffix}"
+        # Single-slice reductions already use this name; Mantid rejects renaming a workspace to itself.
         if str(processed_data_main) != processed_workspace_name:
             processed_data_main = RenameWorkspace(
                 InputWorkspace=processed_data_main,

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -1333,10 +1333,11 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
             else:
                 raise
         processed_workspace_name = f"processed_data_main{output_suffix}"
-        processed_data_main = RenameWorkspace(
-            InputWorkspace=processed_data_main,
-            OutputWorkspace=processed_workspace_name,
-        )
+        if str(processed_data_main) != processed_workspace_name:
+            processed_data_main = RenameWorkspace(
+                InputWorkspace=processed_data_main,
+                OutputWorkspace=processed_workspace_name,
+            )
         processed_samples.append((processed_data_main, name, output_suffix))
 
     if not processed_samples:

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -1287,8 +1287,9 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
     else:
         sample_trans_ws = None
 
-    output = []
-    detectordata = {}
+    # Apply corrections and normalizations to each sample workspace (one per time/log/spin slice).
+    # Results are collected into processed_samples for downstream Q-conversion and binning.
+    processed_samples = []
     for i, raw_sample_ws in enumerate(loaded_ws.sample):
         name = "_slice_{}".format(i + 1)
         if len(loaded_ws.sample) > 1:
@@ -1329,14 +1330,25 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
                 continue
             else:
                 raise
+        processed_samples.append((name, output_suffix, processed_data_main))
 
-        # binning
-        subpixel_kwargs = dict()
-        if reduction_config["useSubpixels"] is True:
-            subpixel_kwargs = {
-                "n_horizontal": reduction_config["subpixelsX"],
-                "n_vertical": reduction_config["subpixelsY"],
-            }
+    if not processed_samples:
+        raise NoDataProcessedError
+
+    # Subpixel binning
+    subpixel_kwargs = dict()
+    if reduction_config["useSubpixels"] is True:
+        subpixel_kwargs = {
+            "n_horizontal": reduction_config["subpixelsX"],
+            "n_vertical": reduction_config["subpixelsY"],
+        }
+
+    #
+    # Convert each processed workspace to Q-space and bin into 1D/2D profiles.
+    #
+    output = []
+    detectordata = {}
+    for name, output_suffix, processed_data_main in processed_samples:
         iq1d_main_in = convert_to_q(processed_data_main, mode="scalar", **subpixel_kwargs)
         iq2d_main_in = convert_to_q(processed_data_main, mode="azimuthal", **subpixel_kwargs)
         if bool(autoWedgeOpts):  # determine wedges automatically
@@ -1387,11 +1399,6 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
         output.append(current_output)
 
         detectordata[name] = {"main": {"i1d": i1d_main_out, "iqxqy": iq2d_main_out}}
-
-    try:
-        processed_data_main
-    except NameError:
-        raise NoDataProcessedError
 
     # save reduction log
 

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -13,6 +13,7 @@ from mantid.simpleapi import (
     mtd,
     MaskDetectors,
     MoveInstrumentComponent,
+    RenameWorkspace,
     SaveNexusProcessed,
     RemoveWorkspaceHistory,
 )
@@ -47,6 +48,7 @@ from drtsans.mono.normalization import (
     NoMonitorMetadataError,
 )
 from drtsans.path import allow_overwrite
+from drtsans.polarization import polarized_sample, polarization_decoder
 from drtsans.mono.transmission import apply_transmission_correction, calculate_transmission
 from drtsans.path import abspath, abspaths, registered_workspace
 from drtsans.plots import plot_detector, plot_IQazimuthal, plot_i1d
@@ -1330,10 +1332,22 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
                 continue
             else:
                 raise
-        processed_samples.append((name, output_suffix, processed_data_main))
+        processed_workspace_name = f"processed_data_main{output_suffix}"
+        processed_data_main = RenameWorkspace(
+            InputWorkspace=processed_data_main,
+            OutputWorkspace=processed_workspace_name,
+        )
+        processed_samples.append((processed_data_main, name, output_suffix))
 
     if not processed_samples:
         raise NoDataProcessedError
+
+    if polarized_sample(reduction_config):
+        device_cross_sections = [ws for ws, _, _ in processed_samples]  # (S^0, S^1) or (S^00, S^0pi, S^10, S^1pi)
+        spin_states = polarization_decoder(device_cross_sections, reduction_config)  # (S^up, S^down),...
+        processed_samples = [
+            (ws, name, output_suffix) for (_, name, output_suffix), ws in zip(processed_samples, spin_states)
+        ]
 
     # Subpixel binning
     subpixel_kwargs = dict()
@@ -1348,7 +1362,7 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
     #
     output = []
     detectordata = {}
-    for name, output_suffix, processed_data_main in processed_samples:
+    for processed_data_main, name, output_suffix in processed_samples:
         iq1d_main_in = convert_to_q(processed_data_main, mode="scalar", **subpixel_kwargs)
         iq2d_main_in = convert_to_q(processed_data_main, mode="azimuthal", **subpixel_kwargs)
         if bool(autoWedgeOpts):  # determine wedges automatically

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -18,7 +18,6 @@ from mantid.simpleapi import (
     RenameWorkspace,
 )
 from matplotlib.colors import LogNorm
-import matplotlib.pyplot as plt
 
 from drtsans import getWedgeSelection, subtract_background, NoDataProcessedError
 from drtsans.beam_finder import center_detector, fbc_options_json, find_beam_center
@@ -1520,9 +1519,8 @@ def plot_reduction_output(
             symmetric_wedges=symmetric_wedges,
             qmin=qmin,
             qmax=qmax,
+            close_figures=close_figures,
         )
-        if close_figures:
-            plt.clf()
         for j in range(len(out.I1D_main)):
             add_suffix = ""
             if len(out.I1D_main) > 1:
@@ -1534,11 +1532,8 @@ def plot_reduction_output(
                 log_scale=loglog,
                 backend="mpl",
                 errorbar_kwargs={"label": "main"},
+                close_figures=close_figures,
             )
-            if close_figures:
-                plt.clf()
-        if close_figures:
-            plt.close()
     # allow overwrite
     allow_overwrite(os.path.join(output_dir, "1D"))
     allow_overwrite(os.path.join(output_dir, "2D"))

--- a/src/drtsans/mono/gpsans/api.py
+++ b/src/drtsans/mono/gpsans/api.py
@@ -15,6 +15,7 @@ from mantid.simpleapi import (
     MoveInstrumentComponent,
     SaveNexusProcessed,
     RemoveWorkspaceHistory,
+    RenameWorkspace,
 )
 from matplotlib.colors import LogNorm
 import matplotlib.pyplot as plt
@@ -47,7 +48,7 @@ from drtsans.mono.normalization import (
     NoMonitorMetadataError,
 )
 from drtsans.path import allow_overwrite
-from drtsans.polarization import polarized_sample, polarization_decoder
+from drtsans.polarization import PolarizationState, polarized_sample, polarization_decoder
 from drtsans.mono.transmission import apply_transmission_correction, calculate_transmission
 from drtsans.path import abspath, abspaths, registered_workspace
 from drtsans.plots import plot_detector, plot_IQazimuthal, plot_i1d
@@ -1339,9 +1340,11 @@ def reduce_single_configuration(loaded_ws, reduction_input, prefix="", skip_nan=
     if polarized_sample(reduction_config):
         device_cross_sections = [ws for ws, _, _ in processed_samples]  # (S^0, S^1) or (S^00, S^0pi, S^10, S^1pi)
         spin_states = polarization_decoder(device_cross_sections, reduction_config)  # (S^up, S^down),...
-        processed_samples = [
-            (ws, name, output_suffix) for (_, name, output_suffix), ws in zip(processed_samples, spin_states)
-        ]
+        processed_samples = list()
+        for ws in spin_states:
+            suffix = str(PolarizationState.get(ws))  # "up", "down", "up_down", "up_up",...
+            renamed = RenameWorkspace(InputWorkspace=ws, OutputWorkspace=f"processed_data_main_{suffix}")
+            processed_samples.append((renamed, f"_slice_{suffix}", f"_{suffix}"))
 
     # Subpixel binning
     subpixel_kwargs = dict()

--- a/src/drtsans/plots/api.py
+++ b/src/drtsans/plots/api.py
@@ -132,7 +132,15 @@ def _q_label(backend: str, subscript=""):
         return label + " (1/{})".format("\u212b")
 
 
-def plot_IQmod(workspaces, filename, loglog=True, backend: str = "d3", errorbar_kwargs=None, **kwargs):
+def plot_IQmod(
+    workspaces,
+    filename,
+    loglog=True,
+    backend: str = "d3",
+    errorbar_kwargs=None,
+    close_figures=False,
+    **kwargs,
+):
     """Save a plot representative of the supplied workspaces
 
     Parameters
@@ -150,6 +158,9 @@ def plot_IQmod(workspaces, filename, loglog=True, backend: str = "d3", errorbar_
         Optional arguments to :py:obj:`matplotlib.axes.Axes.errorbar`
         Can be a comma separated list for each workspace
         e.g. ``{'label':'main,wing,both', 'color':'r,b,g', 'marker':'o,v,.'}``
+    close_figures: bool
+        Close the matplotlib figure after saving. By default, keep pyplot-managed figures available for callers
+        that inspect or display them after plotting.
     kwargs: dict
         Additional key word arguments for :py:obj:`matplotlib.axes.Axes`
 
@@ -166,25 +177,31 @@ def plot_IQmod(workspaces, filename, loglog=True, backend: str = "d3", errorbar_
             raise RuntimeError('Do not know how to plot type="{}"'.format(datatype))
 
     fig, ax = plt.subplots()
-    for n, workspace in enumerate(workspaces):
-        eb, _, _ = ax.errorbar(workspace.mod_q, workspace.intensity, yerr=workspace.error)
-        for key in errorbar_kwargs:
-            value = [v.strip() for v in errorbar_kwargs[key].split(",")]
-            plt.setp(eb, key, value[min(n, len(value) - 1)])
-    ax.set_xlabel(_q_label(backend))
-    ax.set_ylabel("Intensity")
-    if loglog:
-        ax.set_xscale("log")
-        ax.set_yscale("log")
+    saved = False
+    try:
+        for n, workspace in enumerate(workspaces):
+            eb, _, _ = ax.errorbar(workspace.mod_q, workspace.intensity, yerr=workspace.error)
+            for key in errorbar_kwargs:
+                value = [v.strip() for v in errorbar_kwargs[key].split(",")]
+                plt.setp(eb, key, value[min(n, len(value) - 1)])
+        ax.set_xlabel(_q_label(backend))
+        ax.set_ylabel("Intensity")
+        if loglog:
+            ax.set_xscale("log")
+            ax.set_yscale("log")
 
-    handles, labels = ax.get_legend_handles_labels()
-    if handles:
-        ax.legend(handles, labels)
+        handles, labels = ax.get_legend_handles_labels()
+        if handles:
+            ax.legend(handles, labels)
 
-    if kwargs:
-        plt.setp(ax, **kwargs)
+        if kwargs:
+            plt.setp(ax, **kwargs)
 
-    _save_file(fig, filename, backend)
+        _save_file(fig, filename, backend)
+        saved = True
+    finally:
+        if close_figures or not saved:
+            plt.close(fig)
 
 
 def plotly_IQmod(
@@ -280,7 +297,9 @@ def plotly_i1d(
     return plotly_IQmod(profiles, labels, title=title, loglog=loglog)
 
 
-def plot_I1DAnnular(workspaces, filename, logy=True, backend: str = "d3", errorbar_kwargs=None, **kwargs):
+def plot_I1DAnnular(
+    workspaces, filename, logy=True, backend: str = "d3", errorbar_kwargs=None, close_figures=False, **kwargs
+):
     """Save a plot representative of the supplied I(phi) workspaces
 
     Parameters
@@ -298,6 +317,9 @@ def plot_I1DAnnular(workspaces, filename, logy=True, backend: str = "d3", errorb
         Optional arguments to :py:obj:`matplotlib.axes.Axes.errorbar`
         Can be a comma separated list for each workspace
         e.g. ``{'label':'main,wing,both', 'color':'r,b,g', 'marker':'o,v,.'}``
+    close_figures: bool
+        Close the matplotlib figure after saving. By default, keep pyplot-managed figures available for callers
+        that inspect or display them after plotting.
     kwargs: dict
         Additional key word arguments for :py:obj:`matplotlib.axes.Axes`
 
@@ -315,28 +337,42 @@ def plot_I1DAnnular(workspaces, filename, logy=True, backend: str = "d3", errorb
             raise RuntimeError('Do not know how to plot type="{}"'.format(datatype))
 
     fig, ax = plt.subplots()
-    for n, workspace in enumerate(workspaces):
-        eb, _, _ = ax.errorbar(workspace.phi, workspace.intensity, yerr=workspace.error)
-        for key in errorbar_kwargs:
-            value = [v.strip() for v in errorbar_kwargs[key].split(",")]
-            plt.setp(eb, key, value[min(n, len(value) - 1)])
-    ax.set_xlabel("$\\phi$ (degrees)")
-    ax.set_ylabel("Intensity")
-    if logy:
-        # only setting log for y scale, since log scale for the x axis (annular angle) doesn't make sense
-        ax.set_yscale("log")
+    saved = False
+    try:
+        for n, workspace in enumerate(workspaces):
+            eb, _, _ = ax.errorbar(workspace.phi, workspace.intensity, yerr=workspace.error)
+            for key in errorbar_kwargs:
+                value = [v.strip() for v in errorbar_kwargs[key].split(",")]
+                plt.setp(eb, key, value[min(n, len(value) - 1)])
+        ax.set_xlabel("$\\phi$ (degrees)")
+        ax.set_ylabel("Intensity")
+        if logy:
+            # only setting log for y scale, since log scale for the x axis (annular angle) doesn't make sense
+            ax.set_yscale("log")
 
-    handles, labels = ax.get_legend_handles_labels()
-    if handles:
-        ax.legend(handles, labels)
+        handles, labels = ax.get_legend_handles_labels()
+        if handles:
+            ax.legend(handles, labels)
 
-    if kwargs:
-        plt.setp(ax, **kwargs)
+        if kwargs:
+            plt.setp(ax, **kwargs)
 
-    _save_file(fig, filename, backend)
+        _save_file(fig, filename, backend)
+        saved = True
+    finally:
+        if close_figures or not saved:
+            plt.close(fig)
 
 
-def plot_i1d(workspaces, filename, log_scale=True, backend: str = "d3", errorbar_kwargs=None, **kwargs):
+def plot_i1d(
+    workspaces,
+    filename,
+    log_scale=True,
+    backend: str = "d3",
+    errorbar_kwargs=None,
+    close_figures=False,
+    **kwargs,
+):
     """Save a plot representative of the supplied workspaces
 
     Parameters
@@ -357,6 +393,9 @@ def plot_i1d(workspaces, filename, log_scale=True, backend: str = "d3", errorbar
         e.g. ``{'label':'main,wing,both', 'color':'r,b,g', 'marker':'o,v,.'}``
     kwargs: dict
         Additional key word arguments for :py:obj:`matplotlib.axes.Axes`
+    close_figures: bool
+        Close the matplotlib figure after saving. By default, keep pyplot-managed figures available for callers
+        that inspect or display them after plotting.
 
     """
     if not isinstance(workspaces, (list, tuple)):
@@ -373,9 +412,9 @@ def plot_i1d(workspaces, filename, log_scale=True, backend: str = "d3", errorbar
         raise RuntimeError(f"Cannot plot different data types in the same plot={datatypes}")
 
     if datatypes[0] == DataType.IQ_MOD:
-        plot_IQmod(workspaces, filename, log_scale, backend, errorbar_kwargs, **kwargs)
+        plot_IQmod(workspaces, filename, log_scale, backend, errorbar_kwargs, close_figures, **kwargs)
     else:  # can only be DataType.I_ANNULAR
-        plot_I1DAnnular(workspaces, filename, log_scale, backend, errorbar_kwargs, **kwargs)
+        plot_I1DAnnular(workspaces, filename, log_scale, backend, errorbar_kwargs, close_figures, **kwargs)
 
 
 def _create_ring_roi(iq2d, q_min, q_max, input_roi) -> np.ndarray:
@@ -567,6 +606,7 @@ def plot_IQazimuthal(
     symmetric_wedges: bool = True,
     mask_alpha=0.6,
     imshow_kwargs: Dict = {},
+    close_figures=False,
     **kwargs,
 ):
     """Save a plot of I(Qx, Qy).
@@ -597,6 +637,9 @@ def plot_IQazimuthal(
         Which backend to save the file using
     imshow_kwargs: ~dict
         Optional arguments to :py:obj:`matplotlib.axes.Axes.imshow` e.g. ``{"norm": LogNorm()}``
+    close_figures: bool
+        Close the matplotlib figure after saving. By default, keep pyplot-managed figures available for callers
+        that inspect or display them after plotting.
     kwargs: ~dict
         Additional key word arguments for :py:obj:`matplotlib.axes.Axes`
     """
@@ -627,42 +670,48 @@ def plot_IQazimuthal(
 
     # put together the plot
     fig, ax = plt.subplots()
-    current_cmap = matplotlib.colormaps.get_cmap("viridis")
-    current_cmap.set_bad(color="grey")
-    qxmin = workspace.qx.min()
-    qxmax = workspace.qx.max()
-    qymin = workspace.qy.min()
-    qymax = workspace.qy.max()
-    pcm = ax.imshow(
-        intensity,
-        extent=(qxmin, qxmax, qymin, qymax),
-        origin="lower",
-        aspect="auto",
-        **imshow_kwargs,
-    )
+    saved = False
+    try:
+        current_cmap = matplotlib.colormaps.get_cmap("viridis")
+        current_cmap.set_bad(color="grey")
+        qxmin = workspace.qx.min()
+        qxmax = workspace.qx.max()
+        qymin = workspace.qy.min()
+        qymax = workspace.qy.max()
+        pcm = ax.imshow(
+            intensity,
+            extent=(qxmin, qxmax, qymin, qymax),
+            origin="lower",
+            aspect="auto",
+            **imshow_kwargs,
+        )
 
-    # add calculated region of interest
-    ax.imshow(
-        roi,
-        alpha=mask_alpha,
-        extent=(qxmin, qxmax, qymin, qymax),
-        cmap="gray",
-        vmax=roi.max(),
-        interpolation="none",
-        origin="lower",
-        aspect="auto",
-    )
-    pcm.cmap.set_bad(alpha=0.5)
+        # add calculated region of interest
+        ax.imshow(
+            roi,
+            alpha=mask_alpha,
+            extent=(qxmin, qxmax, qymin, qymax),
+            cmap="gray",
+            vmax=roi.max(),
+            interpolation="none",
+            origin="lower",
+            aspect="auto",
+        )
+        pcm.cmap.set_bad(alpha=0.5)
 
-    # rest of plotting arguments
-    fig.colorbar(pcm, ax=ax)
-    ax.set_xlabel(_q_label(backend, "x"))
-    ax.set_ylabel(_q_label(backend, "y"))
+        # rest of plotting arguments
+        fig.colorbar(pcm, ax=ax)
+        ax.set_xlabel(_q_label(backend, "x"))
+        ax.set_ylabel(_q_label(backend, "y"))
 
-    if kwargs:
-        plt.setp(ax, **kwargs)
+        if kwargs:
+            plt.setp(ax, **kwargs)
 
-    _save_file(fig, filename, backend)
+        _save_file(fig, filename, backend)
+        saved = True
+    finally:
+        if close_figures or not saved:
+            plt.close(fig)
 
 
 def plot_detector(

--- a/src/drtsans/polarization.py
+++ b/src/drtsans/polarization.py
@@ -229,7 +229,7 @@ def polarized_sample(reduction_parameters: dict) -> bool:
     if reduction_config.get("polarization", {}).get("level", None) is None:
         if reduction_config == reduction_parameters:
             logger.warning("Unable to resolve polarization level. Setting to NONE by default.")
-            reduction_config["polarization"] = {"level": str(PolarizationLevel.NONE)}
+            reduction_config.setdefault("polarization", {})["level"] = str(PolarizationLevel.NONE)
         else:
             sample = reduction_parameters["sample"]["runNumber"].strip()
             multiple_samples = len(sample.split(",")) > 1
@@ -245,7 +245,7 @@ def polarized_sample(reduction_parameters: dict) -> bool:
             level = PolarizationLevel.get(sample_filepath)
             if multiple_samples and level != PolarizationLevel.NONE:
                 raise ValueError("Can't do polarization reduction on summed data sets")
-            reduction_config["polarization"] = {"level": str(level)}
+            reduction_config.setdefault("polarization", {})["level"] = str(level)
 
     return reduction_config["polarization"]["level"] != PolarizationLevel.NONE
 

--- a/src/drtsans/polarization.py
+++ b/src/drtsans/polarization.py
@@ -9,12 +9,11 @@ from typing import Any, ClassVar, Generator, List, Optional, Union
 import h5py
 from mantid.api import AnalysisDataService
 from mantid.dataobjects import EventWorkspace
-from mantid.simpleapi import CreateSingleValuedWorkspace, DeleteLog, DeleteWorkspace, logger, mtd, RenameWorkspace
+from mantid.simpleapi import DeleteLog, logger, mtd
 import numpy as np
 import sympy as sp
 
 # drtsans imports
-from drtsans.api import _set_uncertainty_from_numpy
 from drtsans.path import abspath
 from drtsans.samplelogs import SampleLogs
 from drtsans.type_hints import MantidWorkspace
@@ -175,7 +174,6 @@ __all__ = [
     "PV_ANALYZER",
     "PV_ANALYZER_FLIPPER",
     "PV_ANALYZER_VETO",
-    "half_polarization",
     "SimulatedPolarizationLogs",
 ]
 
@@ -248,172 +246,6 @@ def polarized_sample(reduction_parameters: dict) -> bool:
             reduction_config.setdefault("polarization", {})["level"] = str(level)
 
     return reduction_config["polarization"]["level"] != PolarizationLevel.NONE
-
-
-def _calc_flipping_ratio(polarization):
-    """Calculates the flipping ratio from the polarization state
-
-    Parameters
-    ----------
-    polarization: str, ~mantid.api.MatrixWorkspace
-        Polarization state
-
-    Returns
-    -------
-    ~mantid.api.MatrixWorkspace
-        The ratio of flipping
-    """
-    value = polarization.extractY()[0]
-    uncertainty = polarization.extractE()[0]
-    if len(value) == 1 and len(uncertainty) == 1:
-        value, uncertainty = value[0], uncertainty[0]
-
-    uncertainty = 2.0 * uncertainty / np.square(1 - value)
-    value = (1 + value) / (1 - value)
-
-    if isinstance(value, float):  # create a single value workspace
-        return CreateSingleValuedWorkspace(
-            DataValue=value,
-            ErrorValue=uncertainty,
-            OutputWorkspace=mtd.unique_hidden_name(),
-            EnableLogging=False,
-        )
-    else:
-        # if it is an array should call CreateWorkspace(EnableLogging=False)
-        raise NotImplementedError("Somebody needs to create an output from {} (type={})".format(value, type(value)))
-
-
-def _calc_half_polarization_up(flipper_off, flipper_on, efficiency, flipping_ratio):
-    """This calculates the spin up workspace
-
-    Parameters
-    ----------
-    flipper_off_workspace: str, ~mantid.api.MatrixWorkspace
-        Flipper off measurement
-    flipper_on_workspace: str, ~mantid.api.MatrixWorkspace
-        Flipper on measurement
-    efficiency: ~mantid.api.MatrixWorkspace
-        Flipper efficiency
-    flipping_ratio: ~mantid.api.MatrixWorkspace
-        The ratio of flipping
-
-    Returns
-    -------
-    ~mantid.api.MatrixWorkspace
-        The spin up workspace
-    """
-    __spin_up = flipper_off + (flipper_off - flipper_on) / (efficiency * (flipping_ratio - 1.0))
-
-    e = efficiency.extractY()[0]
-    F = flipping_ratio.extractY()[0]
-
-    # the uncertainties (numerically) aren't correct because of build-up of numerical errors.
-    # Recalculate them based on the proper equation based on a hand calculation of the partial derivatives
-    m0_part = np.square(flipper_off.extractE()[0][0] * (1 + 1 / (e * (F - 1))))
-    m1_part = np.square(flipper_on.extractE()[0][0] * (1 / (e * (F - 1))))
-
-    mixed = np.square((flipper_off.extractY()[0][0] - flipper_on.extractY()[0][0]) / (e * (F - 1)))
-    mixed *= np.square(efficiency.extractE()[0][0] / e) + np.square(flipping_ratio.extractE()[0][0] / (F - 1))
-    sup_err = np.sqrt(m0_part + m1_part + mixed)
-
-    # set the uncertainty in the workspace
-    __spin_up = _set_uncertainty_from_numpy(__spin_up, sup_err)
-
-    return __spin_up
-
-
-def _calc_half_polarization_down(flipper_off, flipper_on, efficiency, flipping_ratio):
-    """This calculates the spin down workspace
-
-    Parameters
-    ----------
-    flipper_off_workspace: str, ~mantid.api.MatrixWorkspace
-        Flipper off measurement
-    flipper_on_workspace: str, ~mantid.api.MatrixWorkspace
-        Flipper on measurement
-    efficiency: ~mantid.api.MatrixWorkspace
-        Flipper efficiency
-    flipping_ratio: ~mantid.api.MatrixWorkspace
-        The ratio of flipping
-
-    Returns
-    -------
-    ~mantid.api.MatrixWorkspace
-        The spin down workspace
-    """
-    __spin_down = flipper_off - (flipper_off - flipper_on) / (efficiency * (1.0 - 1.0 / flipping_ratio))
-
-    e = efficiency.extractY()[0]
-    F = flipping_ratio.extractY()[0]
-
-    # the uncertainties (numerically) aren't correct because of build-up of numerical errors.
-    # Recalculate them based on the proper equation based on a hand calculation of the partial derivatives
-    m0_part = np.square(flipper_off.extractE()[0][0] * (1 - 1 / (e * (1 - 1 / F))))
-    m1_part = np.square(flipper_on.extractE()[0][0] * (1 / (e * (1 - 1 / F))))
-    mixed = np.square((flipper_off.extractY()[0][0] - flipper_on.extractY()[0][0]) / (e * (1 - 1 / F)))
-    mixed *= np.square(efficiency.extractE()[0][0] / e) + np.square(
-        flipping_ratio.extractE()[0][0] / (F * F * (1 - 1 / F))
-    )
-
-    sdn_err = np.sqrt(m0_part + m1_part + mixed)
-
-    # set the uncertainty in the workspace
-    __spin_down = _set_uncertainty_from_numpy(__spin_down, sdn_err)
-
-    return __spin_down
-
-
-def half_polarization(
-    flipper_off_workspace,
-    flipper_on_workspace,
-    polarization,
-    efficiency,
-    spin_up_workspace=None,
-    spin_down_workspace=None,
-):
-    """Calculate the spin up/down workspaces from flipper on/off.
-
-    **Mantid algorithms used:**
-    :ref:`RenameWorkspace <algm-RenameWorkspace-v1>`
-
-    Parameters
-    ----------
-    flipper_off_workspace: str, ~mantid.api.MatrixWorkspace
-        Flipper off measurement
-    flipper_on_workspace: str, ~mantid.api.MatrixWorkspace
-        Flipper on measurement
-    polarization: str, ~mantid.api.MatrixWorkspace
-        Polarization state
-    efficiency: str, ~mantid.api.MatrixWorkspace
-        Flipper efficiency
-    spin_up_workspace: str
-        Name of the resulting spin up workspace. If :py:obj:`None`, then
-        ``flipper_off_workspace`` will be overwritten.
-    spin_down_workspace: str
-        Name of the resulting spin down workspace. If :py:obj:`None`, then
-        ``flipper_on_workspace`` will be overwritten.
-
-    Returns
-    -------
-    py:obj:`tuple` of 2 ~mantid.api.MatrixWorkspace
-    """
-    if spin_up_workspace is None:
-        spin_up_workspace = str(flipper_off_workspace)
-    if spin_down_workspace is None:
-        spin_down_workspace = str(flipper_on_workspace)
-
-    # this is denoted as "F" in the master document
-    flipping_ratio = _calc_flipping_ratio(polarization)
-
-    __spin_up = _calc_half_polarization_up(flipper_off_workspace, flipper_on_workspace, efficiency, flipping_ratio)
-    __spin_down = _calc_half_polarization_down(flipper_off_workspace, flipper_on_workspace, efficiency, flipping_ratio)
-
-    spin_up_workspace = RenameWorkspace(InputWorkspace=__spin_up, OutputWorkspace=spin_up_workspace)
-    spin_down_workspace = RenameWorkspace(InputWorkspace=__spin_down, OutputWorkspace=spin_down_workspace)
-
-    DeleteWorkspace(flipping_ratio)
-
-    return (spin_up_workspace, spin_down_workspace)
 
 
 class PolarizationDecoder:

--- a/src/drtsans/polarization.py
+++ b/src/drtsans/polarization.py
@@ -9,8 +9,9 @@ from typing import ClassVar, Generator, List, Optional, Union
 import h5py
 from mantid.api import AnalysisDataService
 from mantid.dataobjects import EventWorkspace
-from mantid.simpleapi import CreateSingleValuedWorkspace, DeleteWorkspace, logger, mtd, RenameWorkspace
+from mantid.simpleapi import CreateSingleValuedWorkspace, DeleteLog, DeleteWorkspace, logger, mtd, RenameWorkspace
 import numpy as np
+import sympy as sp
 
 # drtsans imports
 from drtsans.api import _set_uncertainty_from_numpy
@@ -104,13 +105,13 @@ class PolarizationLevel(StrEnum):
 class PolarizationCrossSection(StrEnum):
     """Enumerate the possible spin cross-section states based on flipper and analyzer status."""
 
-    NONE = "none"  # no polarizer and no analyzer
-    OFF = "off"  # flipper off, no analyzer
-    ON = "on"  # flipper on, no analyzer
-    OFF_OFF = "off_off"  # flipper off, analyzer off
-    OFF_ON = "off_on"  # flipper off, analyzer on
-    ON_OFF = "on_off"  # flipper on, analyzer off
-    ON_ON = "on_on"  # flipper on, analyzer on
+    NONE = "none"  # polarizer and analyzer disengaged
+    OFF = "off"  # polarizer flipper off, analyzer disengaged
+    ON = "on"  # polarizer flipper on, analyzer disengaged
+    OFF_OFF = "off_off"  # polarizer flipper off, analyzer at Zero state
+    OFF_ON = "off_on"  # polarizer flipper off, analyzer at Pi state
+    ON_OFF = "on_off"  # polarizer flipper on, analyzer at Zero state
+    ON_ON = "on_on"  # polarizer flipper on, analyzer at Pi state
 
     @classmethod
     def get(cls, workspace: MantidWorkspace) -> "PolarizationCrossSection":
@@ -413,6 +414,87 @@ def half_polarization(
     DeleteWorkspace(flipping_ratio)
 
     return (spin_up_workspace, spin_down_workspace)
+
+
+class PolarizationDecoder:
+    """Base class for polarization decoders."""
+
+    _x = sp.Symbol("x")  # wavelength symbol used in all sympy expressions
+
+    @classmethod
+    def _sympify(cls, value) -> sp.Expr:
+        """Parse a config value (string or number) into a sympy expression in x (wavelength)."""
+        return sp.sympify(str(value))
+
+    @classmethod
+    def _lambdify(cls, expr: sp.Expr):
+        """Convert a sympy expression in x into a numpy-callable function."""
+        return sp.lambdify(cls._x, expr, "numpy")
+
+    def __init__(self, reduction_config: dict):
+        polarizer = reduction_config.get("polarization", {}).get("polarizer", {})
+        self.p = self._lambdify(self._sympify(polarizer.get("polarization", "1")))
+        self.e = self._lambdify(self._sympify(polarizer.get("efficiency", "1")))
+
+    def decode(self, device_cross_sections):
+        raise NotImplementedError("Subclasses must implement the decode method.")
+
+
+class HalfPolarizationDecoder(PolarizationDecoder):
+    """Decoder for half polarization data."""
+
+    def decoding_matrix(self, wavelength: float) -> np.ndarray:
+        p = self.p(wavelength)
+        if p <= 0:
+            raise ValueError("Polarization must be greater than zero.")
+        e = self.e(wavelength)
+        if e <= 0:
+            raise ValueError("Flipper efficiency must be greater than zero.")
+        dl = (1 - p) / (2 * e * p)  # spin-down leakage
+        ul = (1 + p) / (2 * e * p)  # spin-up leakage
+        return np.array(
+            [
+                [1 + dl, -dl],
+                [1 - ul, ul],
+            ]
+        )
+
+    def decode(self, device_cross_sections: list[MantidWorkspace]):
+        if len(device_cross_sections) != 2:
+            raise ValueError(
+                f"Half polarization requires exactly 2 device cross-sections, got {len(device_cross_sections)}."
+            )
+
+        # Find out which cross-section is S⁰ and which is S¹
+        by_state = {PolarizationCrossSection.get(ws): ws for ws in device_cross_sections}
+        s0 = by_state[PolarizationCrossSection.OFF]  # flipper off → S⁰
+        s1 = by_state[PolarizationCrossSection.ON]  # flipper on  → S¹
+        spinor = np.array([s0, s1], dtype=object)
+
+        # Find the decoding matrix
+        wavelength = SampleLogs(s0).single_value("wavelength")
+        M = self.decoding_matrix(wavelength).astype(object)
+
+        # Find the spin states from the device cross-sections, then inject the spin state as a sample-log
+        spin_cross_sections = list(M @ spinor)
+        for ws, state in zip(spin_cross_sections, [PolarizationState.UP, PolarizationState.DOWN]):
+            DeleteLog(Workspace=ws, Name=PolarizationCrossSection.logname)  # delete the device cross-section samplelog
+            state.log(ws)  # inject the spin state samplelog
+        return spin_cross_sections
+
+
+class FullPolarizationDecoder(PolarizationDecoder):
+    """Pass-through placeholder for full polarization data."""
+
+    def decode(self, device_cross_sections: list[MantidWorkspace]):
+        return device_cross_sections
+
+
+def polarization_decoder(device_cross_sections, reduction_config):
+    decoders = {"half": HalfPolarizationDecoder, "full": FullPolarizationDecoder}
+    polarization_level = reduction_config["polarization"]["level"]
+    decoder = decoders[polarization_level](reduction_config)
+    return decoder.decode(device_cross_sections)
 
 
 # A simple way to encode the name and specifications for one of the time generators methods of class SimulatedLogs

--- a/src/drtsans/polarization.py
+++ b/src/drtsans/polarization.py
@@ -430,9 +430,9 @@ class PolarizationDecoder:
     Attributes
     ----------
     p : callable
-        Wavelength-dependent incident-beam polarization, bounded in ``(0, 1]``.
+        Wavelength-dependent incident-beam polarization, bounded in ``[-1, 1]``.
     e : callable
-        Wavelength-dependent polarizer flipper efficiency, bounded in ``(0, 1]``.
+        Wavelength-dependent polarizer flipper efficiency, bounded in ``[0, 1]``.
     """
 
     _x = sp.Symbol("x")  # wavelength symbol used in all sympy expressions
@@ -448,9 +448,9 @@ class PolarizationDecoder:
         return sp.lambdify(cls._x, expr, "numpy")
 
     @staticmethod
-    def _validate_unit_interval(name: str, value: float):
+    def _validate_polarization_interval(name: str, value: float):
         """
-        Validate that a polarization or efficiency value is physically meaningful.
+        Validate that a polarization value is physically meaningful.
 
         Parameters
         ----------
@@ -462,10 +462,30 @@ class PolarizationDecoder:
         Raises
         ------
         ValueError
-            If ``value`` is not in the interval ``(0, 1]``.
+            If ``value`` is not in the interval ``[-1, 1]``.
         """
-        if not 0 < value <= 1:
-            raise ValueError(f"{name} must be in the interval (0, 1].")
+        if not -1 <= value <= 1:
+            raise ValueError(f"{name} must be in the interval [-1, 1].")
+
+    @staticmethod
+    def _validate_efficiency_interval(name: str, value: float):
+        """
+        Validate that an efficiency value is physically meaningful.
+
+        Parameters
+        ----------
+        name : str
+            Human-readable name used in the exception message.
+        value : float
+            Value to validate.
+
+        Raises
+        ------
+        ValueError
+            If ``value`` is not in the interval ``[0, 1]``.
+        """
+        if not 0 <= value <= 1:
+            raise ValueError(f"{name} must be in the interval [0, 1].")
 
     def __init__(self, reduction_config: dict):
         """
@@ -528,12 +548,13 @@ class HalfPolarizationDecoder(PolarizationDecoder):
         Raises
         ------
         ValueError
-            If polarizer polarization or flipper efficiency is outside ``(0, 1]``.
+            If polarizer polarization is outside ``[-1, 1]`` or flipper
+            efficiency is outside ``[0, 1]``.
         """
         p = self.p(wavelength)
-        self._validate_unit_interval("Polarization", p)
+        self._validate_polarization_interval("Polarization", p)
         e = self.e(wavelength)
-        self._validate_unit_interval("Flipper efficiency", e)
+        self._validate_efficiency_interval("Flipper efficiency", e)
         dl = (1 - p) / (2 * e * p)  # spin-down leakage
         ul = (1 + p) / (2 * e * p)  # spin-up leakage
         return np.array(
@@ -608,12 +629,13 @@ class FullPolarizationDecoder(PolarizationDecoder):
             Reduction configuration containing optional ``polarization.polarizer``
             and ``polarization.analyzer`` entries. Analyzer ``polarizationZero``
             and ``polarizationPi`` values may be numeric constants or expressions
-            in wavelength symbol ``x``. Missing values default to 1.
+            in wavelength symbol ``x``. Missing values default to 1 and -1,
+            respectively.
         """
         super().__init__(reduction_config)
         analyzer = reduction_config.get("polarization", {}).get("analyzer", {})
-        self.a_0 = self._lambdify(self._sympify(analyzer.get("polarizationZero", "1")))
-        self.a_pi = self._lambdify(self._sympify(analyzer.get("polarizationPi", "1")))
+        self.p_0 = self._lambdify(self._sympify(analyzer.get("polarizationZero", "1")))
+        self.p_pi = self._lambdify(self._sympify(analyzer.get("polarizationPi", "-1")))
 
     def encoding_matrix(self, wavelength: float) -> np.ndarray:
         """
@@ -637,27 +659,31 @@ class FullPolarizationDecoder(PolarizationDecoder):
         Raises
         ------
         ValueError
-            If any polarization or efficiency value is outside ``(0, 1]``.
+            If any polarization value is outside ``[-1, 1]`` or efficiency
+            value is outside ``[0, 1]``.
         """
         p = self.p(wavelength)
-        self._validate_unit_interval("Polarizer polarization", p)
+        self._validate_polarization_interval("Polarizer polarization", p)
         e = self.e(wavelength)
-        self._validate_unit_interval("Flipper efficiency", e)
-        a_0 = self.a_0(wavelength)
-        self._validate_unit_interval("Analyzer zero-state polarization", a_0)
-        a_pi = self.a_pi(wavelength)
-        self._validate_unit_interval("Analyzer pi-state polarization", a_pi)
+        self._validate_efficiency_interval("Flipper efficiency", e)
+        p_0 = self.p_0(wavelength)
+        self._validate_polarization_interval("Analyzer zero-state polarization", p_0)
+        p_pi = self.p_pi(wavelength)
+        self._validate_polarization_interval("Analyzer pi-state polarization", p_pi)
 
+        # Eq. 9.3 of the Master document converts signed polarization to the ratio terms used by Eqs. 9.16-9.19.
+        # For the pi analyzer state, the Master ratio multiplies spin-down transmission terms,
+        # so its ratio is reciprocal to the signed up/down polarization convention used here.
         polarizer_up_fraction = (1 + p) / 2
         polarizer_down_fraction = (1 - p) / 2
 
         flipper_on_up_fraction = e * polarizer_down_fraction + (1 - e) * polarizer_up_fraction
         flipper_on_down_fraction = e * polarizer_up_fraction + (1 - e) * polarizer_down_fraction
 
-        analyzer_0_up_fraction = a_0 / (1 + a_0)
-        analyzer_0_down_fraction = 1 / (1 + a_0)
-        analyzer_pi_up_fraction = 1 / (1 + a_pi)
-        analyzer_pi_down_fraction = a_pi / (1 + a_pi)
+        analyzer_0_up_fraction = (1 + p_0) / 2
+        analyzer_0_down_fraction = (1 - p_0) / 2
+        analyzer_pi_up_fraction = (1 + p_pi) / 2
+        analyzer_pi_down_fraction = (1 - p_pi) / 2
 
         return np.array(
             [

--- a/src/drtsans/polarization.py
+++ b/src/drtsans/polarization.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from enum import StrEnum
 from dataclasses import dataclass
 from math import fsum
-from typing import ClassVar, Generator, List, Optional, Union
+from typing import Any, ClassVar, Generator, List, Optional, Union
 
 # third party imports
 import h5py
@@ -769,7 +769,39 @@ class FullPolarizationDecoder(PolarizationDecoder):
         return spin_cross_sections
 
 
-def polarization_decoder(device_cross_sections, reduction_config):
+def polarization_decoder(
+    device_cross_sections: list[MantidWorkspace],
+    reduction_config: dict[str, Any],
+) -> list[MantidWorkspace]:
+    """
+    Decode measured polarization device cross-sections into spin-state workspaces.
+
+    Parameters
+    ----------
+    device_cross_sections : list of MantidWorkspace
+        Workspaces tagged with polarization device cross-section sample logs.
+        Half-polarization data must contain the ``OFF`` and ``ON`` states; full
+        polarization data must contain ``OFF_OFF``, ``ON_OFF``, ``OFF_ON``, and
+        ``ON_ON`` states.
+    reduction_config : dict
+        Reduction configuration containing ``polarization.level``. Supported
+        levels are ``"half"`` and ``"full"`` and select the corresponding
+        decoder implementation.
+
+    Returns
+    -------
+    list of MantidWorkspace
+        Spin-state workspaces returned by the selected polarization decoder.
+
+    Raises
+    ------
+    KeyError
+        If the polarization level is missing or is not one of the supported
+        decoder levels.
+    ValueError
+        If the selected decoder receives an invalid number of device
+        cross-section workspaces or invalid polarization properties.
+    """
     decoders = {"half": HalfPolarizationDecoder, "full": FullPolarizationDecoder}
     polarization_level = reduction_config["polarization"]["level"]
     decoder = decoders[polarization_level](reduction_config)

--- a/src/drtsans/polarization.py
+++ b/src/drtsans/polarization.py
@@ -448,7 +448,7 @@ class PolarizationDecoder:
         return sp.lambdify(cls._x, expr, "numpy")
 
     @staticmethod
-    def _validate_polarization_interval(name: str, value: float):
+    def _validate_polarization(name: str, value: float):
         """
         Validate that a polarization value is physically meaningful.
 
@@ -462,13 +462,13 @@ class PolarizationDecoder:
         Raises
         ------
         ValueError
-            If ``value`` is not in the interval ``[-1, 1]``.
+            If ``value`` is zero or not in the interval ``[-1, 1]``.
         """
-        if not -1 <= value <= 1:
-            raise ValueError(f"{name} must be in the interval [-1, 1].")
+        if value == 0 or not -1 <= value <= 1:
+            raise ValueError(f"{name} must be non-zero and in the interval [-1, 1].")
 
     @staticmethod
-    def _validate_efficiency_interval(name: str, value: float):
+    def _validate_efficiency(name: str, value: float):
         """
         Validate that an efficiency value is physically meaningful.
 
@@ -482,10 +482,10 @@ class PolarizationDecoder:
         Raises
         ------
         ValueError
-            If ``value`` is not in the interval ``[0, 1]``.
+            If ``value`` is not in the interval ``(0, 1]``.
         """
-        if not 0 <= value <= 1:
-            raise ValueError(f"{name} must be in the interval [0, 1].")
+        if not 0 < value <= 1:
+            raise ValueError(f"{name} must be in the interval (0, 1].")
 
     def __init__(self, reduction_config: dict):
         """
@@ -552,9 +552,9 @@ class HalfPolarizationDecoder(PolarizationDecoder):
             efficiency is outside ``[0, 1]``.
         """
         p = self.p(wavelength)
-        self._validate_polarization_interval("Polarization", p)
+        self._validate_polarization("Polarization", p)
         e = self.e(wavelength)
-        self._validate_efficiency_interval("Flipper efficiency", e)
+        self._validate_efficiency("Flipper efficiency", e)
         dl = (1 - p) / (2 * e * p)  # spin-down leakage
         ul = (1 + p) / (2 * e * p)  # spin-up leakage
         return np.array(
@@ -663,13 +663,13 @@ class FullPolarizationDecoder(PolarizationDecoder):
             value is outside ``[0, 1]``.
         """
         p = self.p(wavelength)
-        self._validate_polarization_interval("Polarizer polarization", p)
+        self._validate_polarization("Polarizer polarization", p)
         e = self.e(wavelength)
-        self._validate_efficiency_interval("Flipper efficiency", e)
+        self._validate_efficiency("Flipper efficiency", e)
         p_0 = self.p_0(wavelength)
-        self._validate_polarization_interval("Analyzer zero-state polarization", p_0)
+        self._validate_polarization("Analyzer zero-state polarization", p_0)
         p_pi = self.p_pi(wavelength)
-        self._validate_polarization_interval("Analyzer pi-state polarization", p_pi)
+        self._validate_polarization("Analyzer pi-state polarization", p_pi)
 
         # Eq. 9.3 of the Master document converts signed polarization to the ratio terms used by Eqs. 9.16-9.19.
         # For the pi analyzer state, the Master ratio multiplies spin-down transmission terms,

--- a/src/drtsans/polarization.py
+++ b/src/drtsans/polarization.py
@@ -417,7 +417,23 @@ def half_polarization(
 
 
 class PolarizationDecoder:
-    """Base class for polarization decoders."""
+    """
+    Base class for converting measured device cross-sections into spin-state cross-sections.
+
+    Parameters
+    ----------
+    reduction_config : dict
+        Reduction configuration containing optional ``polarization.polarizer`` entries.
+        The polarizer ``polarization`` and flipper ``efficiency`` values may be numeric
+        constants or expressions in wavelength symbol ``x``.
+
+    Attributes
+    ----------
+    p : callable
+        Wavelength-dependent incident-beam polarization, bounded in ``(0, 1]``.
+    e : callable
+        Wavelength-dependent polarizer flipper efficiency, bounded in ``(0, 1]``.
+    """
 
     _x = sp.Symbol("x")  # wavelength symbol used in all sympy expressions
 
@@ -431,25 +447,93 @@ class PolarizationDecoder:
         """Convert a sympy expression in x into a numpy-callable function."""
         return sp.lambdify(cls._x, expr, "numpy")
 
+    @staticmethod
+    def _validate_unit_interval(name: str, value: float):
+        """
+        Validate that a polarization or efficiency value is physically meaningful.
+
+        Parameters
+        ----------
+        name : str
+            Human-readable name used in the exception message.
+        value : float
+            Value to validate.
+
+        Raises
+        ------
+        ValueError
+            If ``value`` is not in the interval ``(0, 1]``.
+        """
+        if not 0 < value <= 1:
+            raise ValueError(f"{name} must be in the interval (0, 1].")
+
     def __init__(self, reduction_config: dict):
+        """
+        Load polarizer properties from the reduction configuration.
+
+        Parameters
+        ----------
+        reduction_config : dict
+            Reduction configuration containing optional ``polarization.polarizer``
+            entries for ``polarization`` and ``efficiency``. Missing values default
+            to perfect polarization and perfect flipper efficiency.
+        """
         polarizer = reduction_config.get("polarization", {}).get("polarizer", {})
         self.p = self._lambdify(self._sympify(polarizer.get("polarization", "1")))
         self.e = self._lambdify(self._sympify(polarizer.get("efficiency", "1")))
 
     def decode(self, device_cross_sections):
+        """
+        Decode measured device cross-sections into spin-state cross-sections.
+
+        Parameters
+        ----------
+        device_cross_sections : list
+            Workspaces corresponding to measured polarizer/analyzer device states.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised by the base class. Subclasses implement the instrument
+            geometry for half or full polarization.
+        """
         raise NotImplementedError("Subclasses must implement the decode method.")
 
 
 class HalfPolarizationDecoder(PolarizationDecoder):
-    """Decoder for half polarization data."""
+    """
+    Decoder for half-polarization data.
+
+    Half polarization uses two measured device cross-sections: polarizer flipper
+    off (``S0``) and on (``S1``). The decoder applies the inverse of the 2 x 2
+    encoding matrix from Section 9.1 of the master requirements document to
+    recover spin-up and spin-down cross-sections.
+    """
 
     def decoding_matrix(self, wavelength: float) -> np.ndarray:
+        """
+        Return the half-polarization decoding matrix at a wavelength.
+
+        Parameters
+        ----------
+        wavelength : float
+            Neutron wavelength in Angstrom.
+
+        Returns
+        -------
+        numpy.ndarray
+            A 2 x 2 matrix transforming measured ``[S0, S1]`` device
+            cross-sections into spin-state ``[S_up, S_down]`` cross-sections.
+
+        Raises
+        ------
+        ValueError
+            If polarizer polarization or flipper efficiency is outside ``(0, 1]``.
+        """
         p = self.p(wavelength)
-        if p <= 0:
-            raise ValueError("Polarization must be greater than zero.")
+        self._validate_unit_interval("Polarization", p)
         e = self.e(wavelength)
-        if e <= 0:
-            raise ValueError("Flipper efficiency must be greater than zero.")
+        self._validate_unit_interval("Flipper efficiency", e)
         dl = (1 - p) / (2 * e * p)  # spin-down leakage
         ul = (1 + p) / (2 * e * p)  # spin-up leakage
         return np.array(
@@ -460,6 +544,26 @@ class HalfPolarizationDecoder(PolarizationDecoder):
         )
 
     def decode(self, device_cross_sections: list[MantidWorkspace]):
+        """
+        Decode two half-polarization device cross-sections into spin states.
+
+        Parameters
+        ----------
+        device_cross_sections : list of MantidWorkspace
+            Workspaces tagged with ``PolarizationCrossSection.OFF`` and
+            ``PolarizationCrossSection.ON`` sample logs.
+
+        Returns
+        -------
+        list of MantidWorkspace
+            Decoded spin-up and spin-down workspaces, tagged with
+            ``PolarizationState.UP`` and ``PolarizationState.DOWN``.
+
+        Raises
+        ------
+        ValueError
+            If exactly two device cross-section workspaces are not supplied.
+        """
         if len(device_cross_sections) != 2:
             raise ValueError(
                 f"Half polarization requires exactly 2 device cross-sections, got {len(device_cross_sections)}."
@@ -484,10 +588,159 @@ class HalfPolarizationDecoder(PolarizationDecoder):
 
 
 class FullPolarizationDecoder(PolarizationDecoder):
-    """Pass-through placeholder for full polarization data."""
+    """
+    Decoder for full-polarization data.
+
+    Full polarization uses four measured device cross-sections formed from the
+    polarizer flipper state and the analyzer state. The decoder numerically
+    inverts the wavelength-dependent 4 x 4 encoding matrix from Section 9.2 of
+    the master requirements document to recover the four spin-state
+    cross-sections.
+    """
+
+    def __init__(self, reduction_config: dict):
+        """
+        Load polarizer and analyzer properties from the reduction configuration.
+
+        Parameters
+        ----------
+        reduction_config : dict
+            Reduction configuration containing optional ``polarization.polarizer``
+            and ``polarization.analyzer`` entries. Analyzer ``polarizationZero``
+            and ``polarizationPi`` values may be numeric constants or expressions
+            in wavelength symbol ``x``. Missing values default to 1.
+        """
+        super().__init__(reduction_config)
+        analyzer = reduction_config.get("polarization", {}).get("analyzer", {})
+        self.a_0 = self._lambdify(self._sympify(analyzer.get("polarizationZero", "1")))
+        self.a_pi = self._lambdify(self._sympify(analyzer.get("polarizationPi", "1")))
+
+    def encoding_matrix(self, wavelength: float) -> np.ndarray:
+        """
+        Return the full-polarization encoding matrix at a wavelength.
+
+        The matrix maps spin-state cross-sections ordered as
+        ``[S_up_up, S_up_down, S_down_up, S_down_down]`` to measured device
+        cross-sections ordered as ``[S00, S10, S0pi, S1pi]``.
+
+        Parameters
+        ----------
+        wavelength : float
+            Neutron wavelength in Angstrom.
+
+        Returns
+        -------
+        numpy.ndarray
+            A 4 x 4 encoding matrix built from polarizer polarization, flipper
+            efficiency, and analyzer zero/pi-state polarizations.
+
+        Raises
+        ------
+        ValueError
+            If any polarization or efficiency value is outside ``(0, 1]``.
+        """
+        p = self.p(wavelength)
+        self._validate_unit_interval("Polarizer polarization", p)
+        e = self.e(wavelength)
+        self._validate_unit_interval("Flipper efficiency", e)
+        a_0 = self.a_0(wavelength)
+        self._validate_unit_interval("Analyzer zero-state polarization", a_0)
+        a_pi = self.a_pi(wavelength)
+        self._validate_unit_interval("Analyzer pi-state polarization", a_pi)
+
+        polarizer_up_fraction = (1 + p) / 2
+        polarizer_down_fraction = (1 - p) / 2
+
+        flipper_on_up_fraction = e * polarizer_down_fraction + (1 - e) * polarizer_up_fraction
+        flipper_on_down_fraction = e * polarizer_up_fraction + (1 - e) * polarizer_down_fraction
+
+        analyzer_0_up_fraction = a_0 / (1 + a_0)
+        analyzer_0_down_fraction = 1 / (1 + a_0)
+        analyzer_pi_up_fraction = 1 / (1 + a_pi)
+        analyzer_pi_down_fraction = a_pi / (1 + a_pi)
+
+        return np.array(
+            [
+                [
+                    polarizer_up_fraction * analyzer_0_up_fraction,
+                    polarizer_up_fraction * analyzer_0_down_fraction,
+                    polarizer_down_fraction * analyzer_0_up_fraction,
+                    polarizer_down_fraction * analyzer_0_down_fraction,
+                ],
+                [
+                    flipper_on_up_fraction * analyzer_0_up_fraction,
+                    flipper_on_up_fraction * analyzer_0_down_fraction,
+                    flipper_on_down_fraction * analyzer_0_up_fraction,
+                    flipper_on_down_fraction * analyzer_0_down_fraction,
+                ],
+                [
+                    polarizer_up_fraction * analyzer_pi_up_fraction,
+                    polarizer_up_fraction * analyzer_pi_down_fraction,
+                    polarizer_down_fraction * analyzer_pi_up_fraction,
+                    polarizer_down_fraction * analyzer_pi_down_fraction,
+                ],
+                [
+                    flipper_on_up_fraction * analyzer_pi_up_fraction,
+                    flipper_on_up_fraction * analyzer_pi_down_fraction,
+                    flipper_on_down_fraction * analyzer_pi_up_fraction,
+                    flipper_on_down_fraction * analyzer_pi_down_fraction,
+                ],
+            ]
+        )
 
     def decode(self, device_cross_sections: list[MantidWorkspace]):
-        return device_cross_sections
+        """
+        Decode four full-polarization device cross-sections into spin states.
+
+        Parameters
+        ----------
+        device_cross_sections : list of MantidWorkspace
+            Workspaces tagged with ``OFF_OFF``, ``ON_OFF``, ``OFF_ON``, and
+            ``ON_ON`` device cross-section sample logs.
+
+        Returns
+        -------
+        list of MantidWorkspace
+            Decoded spin-state workspaces ordered as ``UP_UP``, ``UP_DOWN``,
+            ``DOWN_UP``, and ``DOWN_DOWN``. Device cross-section logs are removed
+            and replaced with polarization state logs.
+
+        Raises
+        ------
+        ValueError
+            If exactly four device cross-section workspaces are not supplied.
+        numpy.linalg.LinAlgError
+            If the encoding matrix is singular at the workspace wavelength.
+        """
+        if len(device_cross_sections) != 4:
+            raise ValueError(
+                f"Full polarization requires exactly 4 device cross-sections, got {len(device_cross_sections)}."
+            )
+
+        # Find out which cross-section is S00, S10, S0pi, and S1pi.
+        by_state = {PolarizationCrossSection.get(ws): ws for ws in device_cross_sections}
+        s00 = by_state[PolarizationCrossSection.OFF_OFF]
+        s10 = by_state[PolarizationCrossSection.ON_OFF]
+        s0pi = by_state[PolarizationCrossSection.OFF_ON]
+        s1pi = by_state[PolarizationCrossSection.ON_ON]
+        spinor = np.array([s00, s10, s0pi, s1pi], dtype=object)
+
+        wavelength = SampleLogs(s00).single_value("wavelength")
+        M = np.linalg.inv(self.encoding_matrix(wavelength)).astype(object)
+
+        spin_cross_sections = list(M @ spinor)
+        for ws, state in zip(
+            spin_cross_sections,
+            [
+                PolarizationState.UP_UP,
+                PolarizationState.UP_DOWN,
+                PolarizationState.DOWN_UP,
+                PolarizationState.DOWN_DOWN,
+            ],
+        ):
+            DeleteLog(Workspace=ws, Name=PolarizationCrossSection.logname)
+            state.log(ws)
+        return spin_cross_sections
 
 
 def polarization_decoder(device_cross_sections, reduction_config):

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import Dict, List, Optional, Set, Tuple
 
 # third party imports
-import matplotlib.pyplot as plt
 from mantid.simpleapi import mtd, logger, RebinToWorkspace, SaveNexus, RemoveWorkspaceHistory
 
 # local imports
@@ -1186,7 +1185,7 @@ def parse_auto_wedge_setup(reduction_config: Dict, bin1d_type: str, wedges_min) 
     return autoWedgeOpts, symmetric_wedges
 
 
-def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None):
+def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None, close_figures=True):
     reduction_config = reduction_input["configuration"]
     output_dir = reduction_config["outputDir"]
     outputFilename = reduction_input["outputFileName"]
@@ -1217,8 +1216,8 @@ def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None)
             symmetric_wedges=symmetric_wedges,
             qmin=qmin,
             qmax=qmax,
+            close_figures=close_figures,
         )
-        plt.clf()
         binning_suffix = "Iq"
         if isinstance(out.I1D_main[0], I1DAnnular):
             binning_suffix = "Iphi"
@@ -1233,9 +1232,8 @@ def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None)
                 log_scale=True,
                 backend="mpl",
                 errorbar_kwargs={"label": "main"},
+                close_figures=close_figures,
             )
-            plt.clf()
-    plt.close()
     # change permissions to all files to allow overwrite
     allow_overwrite(output_dir)
 

--- a/tests/integration/drtsans/filterevents/test_spinfilter.py
+++ b/tests/integration/drtsans/filterevents/test_spinfilter.py
@@ -77,6 +77,8 @@ class TestSpinFilter:
         """Test splitting events based on analyzer state only."""
         workspace = gpsans_workspace
         logs = SimulatedPolarizationLogs(
+            polarizer=1,
+            polarizer_flipper=TimesGeneratorSpecs("heartbeat", {"interval": 400.0}),
             analyzer=2,
             analyzer_flipper=TimesGeneratorSpecs("heartbeat", {"interval": 120}),
             analyzer_veto=TimesGeneratorSpecs("binary_pulse", {"interval": 120.0, "alive_duration": 2.0}),

--- a/tests/integration/drtsans/filterevents/test_spinfilter.py
+++ b/tests/integration/drtsans/filterevents/test_spinfilter.py
@@ -74,7 +74,7 @@ class TestSpinFilter:
 
     @pytest.mark.datarepo
     def test_analyzer(self, gpsans_workspace):
-        """Test splitting events based on analyzer state only."""
+        """Test splitting events based on analyzer state with an active polarizer."""
         workspace = gpsans_workspace
         logs = SimulatedPolarizationLogs(
             polarizer=1,

--- a/tests/integration/drtsans/mono/gpsans/test_simulated_events.py
+++ b/tests/integration/drtsans/mono/gpsans/test_simulated_events.py
@@ -509,7 +509,7 @@ def test_split_three_rings(three_rings_pattern: dict, temp_directory: Callable[[
 @mock_patch("drtsans.load.LoadEventNexus", new=_mock_LoadEventNexus)
 def test_half_polarization(three_rings_pattern: dict, temp_directory: Callable[[Any], str]):
     r"""
-    Split the three_rings_pattern into Off_Off and On_Off cross-sections.
+    Split the three_rings_pattern into off and on cross-sections.
 
     The sample run in the "three_rings_pattern" fixture is 1 second long, thus containing 60 pulses in total.
     During a pulse, neutrons scattered by the sample are set to scatter at a particular two_theta value.
@@ -518,8 +518,8 @@ def test_half_polarization(three_rings_pattern: dict, temp_directory: Callable[[
 
     We insert a time-series for PV_POLARIZER_FLIPPER. During the first two seconds it will take a value of 0,
     and a value of 1 during the third second. This will be repeated 20 times to span the 60 pulses.
-    Thus, we expect the Off_Off intensity to contain the first two rings,
-    and the On_Off intensity to contain the third ring.
+    Thus, we expect the off intensity to contain the first two rings,
+    and the on intensity to contain the third ring.
     We do not include a PV_POLARIZER_VETO log. The code should be resilient to this missing log.
 
     We'll be changing the sample logs of the sample Nexus file.
@@ -621,7 +621,7 @@ def test_half_polarization(three_rings_pattern: dict, temp_directory: Callable[[
 @mock_patch("drtsans.load.LoadEventNexus", new=_mock_LoadEventNexus)
 def test_full_polarization(three_rings_pattern: dict, temp_directory: Callable[[Any], str]):
     r"""
-    Split the three_rings_pattern into Off_Off, On_Off, Off_On, and On_On cross-sections.
+    Split the three_rings_pattern into off_off, on_off, off_on, and on_on cross-sections.
 
     The sample run is 1 second long (60 pulses). Neutrons cycle through three two_theta values every
     three pulses, imprinting three rings on the detector.
@@ -631,18 +631,18 @@ def test_full_polarization(three_rings_pattern: dict, temp_directory: Callable[[
 
     The flipper states follow a 6-pulse super-cycle (period = 6/60 s):
 
-        Pulse 0  [0,     1/60) : pol=Off, ana=Off  →  Off_Off  (ring 1°)
-        Pulse 1  [1/60,  2/60) : pol=On,  ana=Off  →  On_Off   (ring 3°)
-        Pulse 2  [2/60,  3/60) : pol=On,  ana=On   →  On_On    (ring 5°)
-        Pulse 3  [3/60,  4/60) : pol=Off, ana=Off  →  Off_Off  (ring 1°)
-        Pulse 4  [4/60,  5/60) : pol=Off, ana=On   →  Off_On   (ring 3°)
-        Pulse 5  [5/60,  6/60) : pol=On,  ana=On   →  On_On    (ring 5°)
+        Pulse 0  [0,     1/60) : pol=off, ana=off  →  off_off  (ring 1°)
+        Pulse 1  [1/60,  2/60) : pol=on,  ana=off  →  on_off   (ring 3°)
+        Pulse 2  [2/60,  3/60) : pol=on,  ana=on   →  on_on    (ring 5°)
+        Pulse 3  [3/60,  4/60) : pol=off, ana=off  →  off_off  (ring 1°)
+        Pulse 4  [4/60,  5/60) : pol=off, ana=on   →  off_on   (ring 3°)
+        Pulse 5  [5/60,  6/60) : pol=on,  ana=on   →  on_on    (ring 5°)
 
     The polarizer flipper uses cycled_intervals [1/60, 2/60, 2/60, 1/60], and the analyzer
     flipper uses cycled_intervals [2/60, 1/60, 1/60, 2/60]. Every interval is >= 1/60 s.
 
-    Over 60 pulses (10 super-cycles) ring 3° contributes equally to On_Off and Off_On
-    (10 pulses each), while rings 1° and 5° contribute 20 pulses each to Off_Off and On_On.
+    Over 60 pulses (10 super-cycles) ring 3° contributes equally to on_off and off_on
+    (10 pulses each), while rings 1° and 5° contribute 20 pulses each to off_off and on_on.
 
     We'll be changing the sample logs of the sample Nexus file.
     Other tests will also try to access the Nexus files, thus we'll copy the files to a temporary
@@ -726,29 +726,29 @@ def test_full_polarization(three_rings_pattern: dict, temp_directory: Callable[[
     reduction_output = reduce_single_configuration(loaded, config)
 
     # Cross-sections appear in the order they are first encountered by the splitter:
-    #   reduction_output[0] → Off_Off  (ring 1°, 20 pulses)
-    #   reduction_output[1] → On_Off   (ring 3°, 10 pulses — half the full ring)
-    #   reduction_output[2] → On_On    (ring 5°, 20 pulses)
-    #   reduction_output[3] → Off_On   (ring 3°, 10 pulses — half the full ring)
+    #   reduction_output[0] → off_off  (ring 1°, 20 pulses)
+    #   reduction_output[1] → on_off   (ring 3°, 10 pulses — half the full ring)
+    #   reduction_output[2] → on_on    (ring 5°, 20 pulses)
+    #   reduction_output[3] → off_on   (ring 3°, 10 pulses — half the full ring)
 
     minimum_peak_intensity = 800.0
 
-    # Off_Off: only the small-angle ring (1°) should be visible
+    # off_off: only the small-angle ring (1°) should be visible
     i_vs_qmod: IQmod = reduction_output[0].I1D_main[0]
     closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][0]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity
 
-    # On_Off: half of the middle ring (3°) — intensity roughly halved relative to a full ring
+    # on_off: half of the middle ring (3°) — intensity roughly halved relative to a full ring
     i_vs_qmod: IQmod = reduction_output[1].I1D_main[0]
     closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][1]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity
 
-    # On_On: only the large-angle ring (5°) should be visible
+    # on_on: only the large-angle ring (5°) should be visible
     i_vs_qmod: IQmod = reduction_output[2].I1D_main[0]
     closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][2]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity
 
-    # Off_On: the other half of the middle ring (3°)
+    # off_on: the other half of the middle ring (3°)
     i_vs_qmod: IQmod = reduction_output[3].I1D_main[0]
     closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][1]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity

--- a/tests/integration/drtsans/mono/gpsans/test_simulated_events.py
+++ b/tests/integration/drtsans/mono/gpsans/test_simulated_events.py
@@ -725,32 +725,42 @@ def test_full_polarization(three_rings_pattern: dict, temp_directory: Callable[[
     # do the actual reduction
     reduction_output = reduce_single_configuration(loaded, config)
 
-    # Cross-sections appear in the order they are first encountered by the splitter:
-    #   reduction_output[0] → off_off  (ring 1°, 20 pulses)
-    #   reduction_output[1] → on_off   (ring 3°, 10 pulses — half the full ring)
-    #   reduction_output[2] → on_on    (ring 5°, 20 pulses)
-    #   reduction_output[3] → off_on   (ring 3°, 10 pulses — half the full ring)
+    # Outputs are Spin States, not Device Cross Sections !
+    # This test uses default values for polarizer and analyzer polarization and efficiencies,
+    # which result in a one-to-one correspondence between Device Cross Sections and Spin States.
+    #
+    #     Device Cross Section   |  Spin State
+    #     ---------------------  |  -----------
+    #     off_off (pol=0, ana=0) |  up_up
+    #     off_on  (pol=0, ana=1) |  up_down
+    #     on_off  (pol=1, ana=0) |  down_up
+    #     on_on   (pol=1, ana=1) |  down_down
+    #
+    #   reduction_output[0] → up_up      (off_off, ring 1°, 20 pulses)
+    #   reduction_output[1] → up_down    (off_on, ring 3°, 10 pulses — half the full ring)
+    #   reduction_output[2] → down_up    (on_off, ring 3°, 10 pulses — half the full ring)
+    #   reduction_output[3] → down_down  (on_on, ring 5°, 20 pulses)
 
     minimum_peak_intensity = 800.0
 
-    # off_off: only the small-angle ring (1°) should be visible
+    # up_up (off_off): only the small-angle ring (1°) should be visible
     i_vs_qmod: IQmod = reduction_output[0].I1D_main[0]
     closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][0]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity
 
-    # on_off: half of the middle ring (3°) — intensity roughly halved relative to a full ring
+    # up_down: half of the middle ring (3°) — intensity roughly halved relative to a full ring
     i_vs_qmod: IQmod = reduction_output[1].I1D_main[0]
     closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][1]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity
 
-    # on_on: only the large-angle ring (5°) should be visible
+    # down_up: the other half of the middle ring (3°)
     i_vs_qmod: IQmod = reduction_output[2].I1D_main[0]
-    closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][2]))
+    closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][1]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity
 
-    # off_on: the other half of the middle ring (3°)
+    # down_down: only the large-angle ring (5°) should be visible
     i_vs_qmod: IQmod = reduction_output[3].I1D_main[0]
-    closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][1]))
+    closest_index = np.argmin(np.abs(i_vs_qmod.mod_q - metadata["Q_at_max_I"][2]))
     assert i_vs_qmod.intensity[closest_index] > minimum_peak_intensity
 
 

--- a/tests/unit/drtsans/filterevents/test_spinfilter.py
+++ b/tests/unit/drtsans/filterevents/test_spinfilter.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from drtsans.filterevents.spinfilter import SpinFilter, extract_times, create_table
 from drtsans.polarization import (
+    PolarizationCrossSection,
     PV_POLARIZER,
     PV_ANALYZER,
     PV_POLARIZER_FLIPPER,
@@ -24,7 +25,7 @@ def _make_workspace_group(xs_ids):
 def _make_samplelogs(xs_id):
     """Return a SampleLogs mock that exposes cross_section_id."""
     sl = MagicMock()
-    sl.__contains__ = MagicMock(side_effect=lambda key: key == "polarization.cross_section")
+    sl.__contains__ = MagicMock(side_effect=lambda key: key == PolarizationCrossSection.logname)
     sl.get = MagicMock(return_value=MagicMock(value=xs_id))
     return sl
 
@@ -85,7 +86,7 @@ def test_extract_times_empty_list_of_times():
 def test_create_table():
     """
     create_table discards the interval predating start_time and produces
-    a first row starting at start_time for the Off_Off cross-section.
+    a first row starting at start_time for the off cross-section.
 
     SplittersWorkspace stores absolute nanosecond timestamps and uses the
     column name 'workspacegroup' (int index).
@@ -105,12 +106,17 @@ def test_create_table():
     table = create_table(changes, start_time=start_time, has_polarizer=True, has_analyzer=False)
 
     row = table.row(0)
-    # The first valid interval is Off_Off; its start is clamped to start_time.
+    # The first valid interval is off; its start is clamped to start_time.
     assert row["start"] == pytest.approx(start_time, rel=1e-9)
     # The stop is the next change event (~73.9 s after start_time in nanoseconds).
     assert row["stop"] == pytest.approx(1114104949939068067, rel=1e-9)
-    # workspacegroup index 0 corresponds to the first cross-section encountered ("Off_Off").
+    # workspacegroup index 0 corresponds to the first cross-section encountered ("off").
     assert row["workspacegroup"] == 0
+
+
+def test_create_table_rejects_analyzer_without_polarizer():
+    with pytest.raises(ValueError, match="Analyzer polarization requires an active polarizer"):
+        create_table([], start_time=0, has_polarizer=False, has_analyzer=True)
 
 
 @patch("drtsans.filterevents.spinfilter.SampleLogs")
@@ -120,7 +126,7 @@ def test_spin_filter_inject_metadata_common_fields(mock_base_sl_cls, mock_worksp
     """inject_metadata inserts slice, number_of_slices, and slice_info for every cross-section."""
     mock_spin_sl_cls.return_value = _make_device_sample_logs(has_polarizer=True, has_analyzer=True)
 
-    xs_ids = ["On_On", "Off_Off"]
+    xs_ids = ["on_on", "off_off"]
     mock_workspace_handle.return_value = _make_workspace_group(xs_ids)
     samplelogs_instances = [_make_samplelogs(xs_id) for xs_id in xs_ids]
     mock_base_sl_cls.side_effect = samplelogs_instances
@@ -130,10 +136,10 @@ def test_spin_filter_inject_metadata_common_fields(mock_base_sl_cls, mock_worksp
     sl0, sl1 = samplelogs_instances
     sl0.insert.assert_any_call("slice", 1)
     sl0.insert.assert_any_call("number_of_slices", 2)
-    sl0.insert.assert_any_call("slice_info", "On_On")
+    sl0.insert.assert_any_call("slice_info", "on_on")
     sl1.insert.assert_any_call("slice", 2)
     sl1.insert.assert_any_call("number_of_slices", 2)
-    sl1.insert.assert_any_call("slice_info", "Off_Off")
+    sl1.insert.assert_any_call("slice_info", "off_off")
 
 
 @patch("drtsans.filterevents.spinfilter.SampleLogs")
@@ -143,7 +149,7 @@ def test_spin_filter_inject_metadata_polarization_fields(mock_base_sl_cls, mock_
     """inject_metadata inserts slice_parameter, cross_section, has_polarizer, has_analyzer, and slice_info."""
     mock_spin_sl_cls.return_value = _make_device_sample_logs(has_polarizer=True, has_analyzer=True)
 
-    xs_ids = ["On_On", "On_Off"]
+    xs_ids = ["on_on", "on_off"]
     mock_workspace_handle.return_value = _make_workspace_group(xs_ids)
     samplelogs_instances = [_make_samplelogs(xs_id) for xs_id in xs_ids]
     mock_base_sl_cls.side_effect = samplelogs_instances
@@ -154,13 +160,13 @@ def test_spin_filter_inject_metadata_polarization_fields(mock_base_sl_cls, mock_
     spin_filter.inject_metadata("output_ws")
 
     sl0, sl1 = samplelogs_instances
-    sl0.insert.assert_any_call("slice_info", "On_On")
-    sl0.insert.assert_any_call("slice_parameter", "polarization.cross_section")
-    sl0.insert.assert_any_call("polarization.cross_section", "On_On")
+    sl0.insert.assert_any_call("slice_info", "on_on")
+    sl0.insert.assert_any_call("slice_parameter", PolarizationCrossSection.logname)
+    sl0.insert.assert_any_call(PolarizationCrossSection.logname, "on_on")
     sl0.insert.assert_any_call("polarization.active_polarizer", 1)
     sl0.insert.assert_any_call("polarization.active_analyzer", 1)
-    sl1.insert.assert_any_call("slice_info", "On_Off")
-    sl1.insert.assert_any_call("polarization.cross_section", "On_Off")
+    sl1.insert.assert_any_call("slice_info", "on_off")
+    sl1.insert.assert_any_call(PolarizationCrossSection.logname, "on_off")
 
 
 @patch("drtsans.filterevents.spinfilter.SampleLogs")
@@ -170,15 +176,15 @@ def test_spin_filter_inject_metadata_unknown_cross_section(mock_base_sl_cls, moc
     """inject_metadata falls back to slice_info when cross_section_id log is absent, or 'Unknown' if also empty."""
     mock_spin_sl_cls.return_value = _make_device_sample_logs(has_polarizer=True, has_analyzer=True)
 
-    mock_workspace_handle.return_value = _make_workspace_group(["On_On"])
+    mock_workspace_handle.return_value = _make_workspace_group(["on_on"])
     sl = MagicMock()
     sl.__contains__ = MagicMock(return_value=False)  # cross_section_id not present
     mock_base_sl_cls.return_value = sl
 
     SpinFilter(MagicMock()).inject_metadata("output_ws")
 
-    sl.insert.assert_any_call("slice_info", "On_On")
-    sl.insert.assert_any_call("polarization.cross_section", "On_On")
+    sl.insert.assert_any_call("slice_info", "on_on")
+    sl.insert.assert_any_call(PolarizationCrossSection.logname, "on_on")
 
 
 @patch("drtsans.filterevents.spinfilter.SampleLogs")
@@ -190,8 +196,8 @@ def test_spin_filter_inject_metadata_no_devices(mock_base_sl_cls, mock_workspace
     # then override the flags after construction.
     mock_spin_sl_cls.return_value = _make_device_sample_logs(has_polarizer=True, has_analyzer=False)
 
-    mock_workspace_handle.return_value = _make_workspace_group(["Off_Off"])
-    samplelogs_instances = [_make_samplelogs("Off_Off")]
+    mock_workspace_handle.return_value = _make_workspace_group(["off_off"])
+    samplelogs_instances = [_make_samplelogs("off_off")]
     mock_base_sl_cls.side_effect = samplelogs_instances
 
     spin_filter = SpinFilter(MagicMock())
@@ -200,7 +206,7 @@ def test_spin_filter_inject_metadata_no_devices(mock_base_sl_cls, mock_workspace
     spin_filter.inject_metadata("output_ws")
 
     sl = samplelogs_instances[0]
-    sl.insert.assert_any_call("slice_info", "Off_Off")
+    sl.insert.assert_any_call("slice_info", "off_off")
     sl.insert.assert_any_call("polarization.active_polarizer", 0)
     sl.insert.assert_any_call("polarization.active_analyzer", 0)
 

--- a/tests/unit/drtsans/mono/gpsans/test_export_to_grasp.py
+++ b/tests/unit/drtsans/mono/gpsans/test_export_to_grasp.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 import pytest
-import os
 import subprocess
 
 
 @pytest.mark.mount_eqsans
 @pytest.mark.datarepo
-def test_grasp_cg2(reference_dir, has_sns_mount, datarepo_dir):
+def test_grasp_cg2(reference_dir, has_sns_mount, datarepo_dir, tmp_path):
     if not has_sns_mount:
         pytest.skip("Do not have /SNS properly mounted on this system")
 
@@ -14,15 +13,15 @@ def test_grasp_cg2(reference_dir, has_sns_mount, datarepo_dir):
     input_filename = "CG2_9177.nxs.h5"
     input_path = str(Path(datarepo_dir.gpsans) / input_filename)
 
-    output_dir = "test_grasp"
+    output_dir = tmp_path / "test_grasp"
     output_filename = "GPSANS_0009177.dat"
-    output_path = os.path.join(os.getcwd(), output_dir, output_filename)
+    output_path = output_dir / output_filename
 
     # run the grasp export command
-    subprocess.run(["grasp_cg2", input_path, output_dir], check=False)
+    subprocess.run(["grasp_cg2", input_path, str(output_dir)], check=True)
 
     # assert the grasp output file was created
-    assert os.path.exists(output_path)
+    assert output_path.exists()
 
     # used to assert the number of lines in the created file
     line_count = 0
@@ -37,10 +36,6 @@ def test_grasp_cg2(reference_dir, has_sns_mount, datarepo_dir):
 
     # assert number of lines is correct
     assert line_count == 201
-
-    # cleanup
-    os.remove(output_path)
-    os.rmdir(output_dir)
 
 
 if __name__ == "__main__":

--- a/tests/unit/drtsans/mono/gpsans/test_polarization.py
+++ b/tests/unit/drtsans/mono/gpsans/test_polarization.py
@@ -459,23 +459,22 @@ class TestPolarizationDecoder:
         with pytest.raises(NotImplementedError):
             PolarizationDecoder({}).decode([])
 
-    @pytest.mark.parametrize("value", [-1.0, 0.0, 1.0])
-    def test_polarization_interval_includes_signed_bounds(self, value):
-        PolarizationDecoder._validate_polarization_interval("Polarization", value)
+    @pytest.mark.parametrize("value", [-1.0, 1.0])
+    def test_polarization_includes_signed_bounds(self, value):
+        PolarizationDecoder._validate_polarization("Polarization", value)
 
-    @pytest.mark.parametrize("value", [-1.1, 1.1])
-    def test_polarization_interval_rejects_outside_signed_bounds(self, value):
-        with pytest.raises(ValueError, match=r"Polarization must be in the interval \[-1, 1\]"):
-            PolarizationDecoder._validate_polarization_interval("Polarization", value)
+    @pytest.mark.parametrize("value", [-1.1, 0.0, 1.1])
+    def test_polarization_rejects_zero_and_outside_signed_bounds(self, value):
+        with pytest.raises(ValueError, match=r"Polarization must be non-zero and in the interval \[-1, 1\]"):
+            PolarizationDecoder._validate_polarization("Polarization", value)
 
-    @pytest.mark.parametrize("value", [0.0, 1.0])
-    def test_efficiency_interval_includes_bounds(self, value):
-        PolarizationDecoder._validate_efficiency_interval("Flipper efficiency", value)
+    def test_efficiency_includes_upper_bound(self):
+        PolarizationDecoder._validate_efficiency("Flipper efficiency", 1.0)
 
-    @pytest.mark.parametrize("value", [-0.1, 1.1])
-    def test_efficiency_interval_rejects_outside_unit_bounds(self, value):
-        with pytest.raises(ValueError, match=r"Flipper efficiency must be in the interval \[0, 1\]"):
-            PolarizationDecoder._validate_efficiency_interval("Flipper efficiency", value)
+    @pytest.mark.parametrize("value", [-0.1, 0.0, 1.1])
+    def test_efficiency_rejects_zero_and_outside_unit_bounds(self, value):
+        with pytest.raises(ValueError, match=r"Flipper efficiency must be in the interval \(0, 1\]"):
+            PolarizationDecoder._validate_efficiency("Flipper efficiency", value)
 
 
 class TestHalfPolarizationDecoder:
@@ -503,17 +502,22 @@ class TestHalfPolarizationDecoder:
 
     def test_polarization_below_negative_one_raises(self):
         decoder = self._make_decoder(polarization=-1.1, efficiency=1.0)
-        with pytest.raises(ValueError, match="Polarization must be in the interval"):
+        with pytest.raises(ValueError, match="Polarization must be non-zero and in the interval"):
             decoder.decoding_matrix(wavelength=6.0)
 
     def test_efficiency_below_zero_raises(self):
         decoder = self._make_decoder(polarization=0.9, efficiency=-0.1)
-        with pytest.raises(ValueError, match="Flipper efficiency must be in the interval"):
+        with pytest.raises(ValueError, match=r"Flipper efficiency must be in the interval \(0, 1\]"):
+            decoder.decoding_matrix(wavelength=6.0)
+
+    def test_efficiency_zero_raises(self):
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.0)
+        with pytest.raises(ValueError, match=r"Flipper efficiency must be in the interval \(0, 1\]"):
             decoder.decoding_matrix(wavelength=6.0)
 
     def test_efficiency_above_one_raises(self):
         decoder = self._make_decoder(polarization=0.9, efficiency=1.1)
-        with pytest.raises(ValueError, match="Flipper efficiency must be in the interval"):
+        with pytest.raises(ValueError, match=r"Flipper efficiency must be in the interval \(0, 1\]"):
             decoder.decoding_matrix(wavelength=6.0)
 
     def test_negative_polarization_is_in_valid_range(self):
@@ -711,7 +715,7 @@ class TestFullPolarizationDecoder:
         config = {
             "polarization": {
                 "polarizer": {"polarization": "-0.5", "efficiency": "0.8"},
-                "analyzer": {"polarizationZero": "0", "polarizationPi": "-0.25"},
+                "analyzer": {"polarizationZero": "0.25", "polarizationPi": "-0.25"},
             }
         }
         decoder = FullPolarizationDecoder(config)
@@ -724,10 +728,14 @@ class TestFullPolarizationDecoder:
         "polarization_config, match",
         [
             ({"polarizer": {"polarization": "-1.1"}}, "Polarizer polarization"),
+            ({"polarizer": {"polarization": "0"}}, "Polarizer polarization"),
             ({"polarizer": {"polarization": "1.1"}}, "Polarizer polarization"),
             ({"polarizer": {"efficiency": "-0.1"}}, "Flipper efficiency"),
+            ({"polarizer": {"efficiency": "0"}}, "Flipper efficiency"),
             ({"polarizer": {"efficiency": "1.1"}}, "Flipper efficiency"),
             ({"analyzer": {"polarizationZero": "-1.1"}}, "Analyzer zero-state polarization"),
+            ({"analyzer": {"polarizationZero": "0"}}, "Analyzer zero-state polarization"),
+            ({"analyzer": {"polarizationPi": "0"}}, "Analyzer pi-state polarization"),
             ({"analyzer": {"polarizationPi": "1.1"}}, "Analyzer pi-state polarization"),
         ],
     )

--- a/tests/unit/drtsans/mono/gpsans/test_polarization.py
+++ b/tests/unit/drtsans/mono/gpsans/test_polarization.py
@@ -7,6 +7,7 @@ import pytest
 
 from drtsans.instruments import empty_instrument_workspace
 from drtsans.polarization import (
+    FullPolarizationDecoder,
     HalfPolarizationDecoder,
     PolarizationDecoder,
     PolarizationLevel,
@@ -395,6 +396,40 @@ def half_pol_workspaces():
             DeleteWorkspace(name)
 
 
+@pytest.fixture
+def full_pol_workspaces():
+    """Four Workspace2D objects tagged with full-polarization cross-section logs and wavelength=6."""
+    config = {
+        "polarization": {
+            "polarizer": {"polarization": str(1.0 / 3.0), "efficiency": "1.0"},
+            "analyzer": {"polarizationZero": "0.5", "polarizationPi": "0.25"},
+        }
+    }
+    spin_values = np.array([13.0, 17.0, 19.0, 23.0])
+    device_values = FullPolarizationDecoder(config).encoding_matrix(wavelength=6.0) @ spin_values
+
+    names, ws_list = [], []
+    for cross_section, y_val in zip(
+        [
+            PolarizationCrossSection.OFF_OFF,
+            PolarizationCrossSection.ON_OFF,
+            PolarizationCrossSection.OFF_ON,
+            PolarizationCrossSection.ON_ON,
+        ],
+        device_values,
+    ):
+        name = mtd.unique_hidden_name()
+        ws = CreateWorkspace(DataX=[5.0, 7.0], DataY=[y_val], DataE=[0.1], OutputWorkspace=name)
+        SampleLogs(ws).insert("wavelength", 6.0)
+        cross_section.log(ws)
+        names.append(name)
+        ws_list.append(ws)
+    yield ws_list, spin_values, config
+    for name in names:
+        if mtd.doesExist(name):
+            DeleteWorkspace(name)
+
+
 class TestPolarizationDecoder:
     def test_constant_polarization_and_efficiency(self):
         config = {"polarization": {"polarizer": {"polarization": "0.9", "efficiency": "0.8"}}}
@@ -450,12 +485,17 @@ class TestHalfPolarizationDecoder:
 
     def test_zero_polarization_raises(self):
         decoder = self._make_decoder(polarization=0.0, efficiency=1.0)
-        with pytest.raises(ValueError, match="Polarization must be greater than zero"):
+        with pytest.raises(ValueError, match="Polarization must be in the interval"):
             decoder.decoding_matrix(wavelength=6.0)
 
     def test_zero_efficiency_raises(self):
         decoder = self._make_decoder(polarization=0.9, efficiency=0.0)
-        with pytest.raises(ValueError, match="Flipper efficiency must be greater than zero"):
+        with pytest.raises(ValueError, match="Flipper efficiency must be in the interval"):
+            decoder.decoding_matrix(wavelength=6.0)
+
+    def test_efficiency_above_one_raises(self):
+        decoder = self._make_decoder(polarization=0.9, efficiency=1.1)
+        with pytest.raises(ValueError, match="Flipper efficiency must be in the interval"):
             decoder.decoding_matrix(wavelength=6.0)
 
     def test_matrix_inverts_encoding(self):
@@ -540,6 +580,169 @@ class TestHalfPolarizationDecoder:
             clean_workspace(ws)
         np.testing.assert_array_almost_equal(result[0].readY(0), [12.0])
         np.testing.assert_array_almost_equal(result[1].readY(0), [6.0])
+
+
+class TestFullPolarizationDecoder:
+    def test_loads_polarizer_and_analyzer_values(self):
+        config = {
+            "polarization": {
+                "polarizer": {"polarization": "0.9", "efficiency": "0.8"},
+                "analyzer": {"polarizationZero": "0.7", "polarizationPi": "0.6"},
+            }
+        }
+        decoder = FullPolarizationDecoder(config)
+
+        assert decoder.p(6.0) == pytest.approx(0.9)
+        assert decoder.e(6.0) == pytest.approx(0.8)
+        assert decoder.a_0(6.0) == pytest.approx(0.7)
+        assert decoder.a_pi(6.0) == pytest.approx(0.6)
+
+    def test_loads_wavelength_dependent_analyzer_values(self):
+        config = {
+            "polarization": {
+                "analyzer": {
+                    "polarizationZero": "0.95 - 0.01*(x - 16)",
+                    "polarizationPi": "0.90 - 0.02*(x - 16)",
+                }
+            }
+        }
+        decoder = FullPolarizationDecoder(config)
+
+        assert decoder.a_0(16.0) == pytest.approx(0.95)
+        assert decoder.a_0(6.0) == pytest.approx(0.95 - 0.01 * (6.0 - 16.0))
+        assert decoder.a_pi(16.0) == pytest.approx(0.90)
+        assert decoder.a_pi(6.0) == pytest.approx(0.90 - 0.02 * (6.0 - 16.0))
+
+    def test_analyzer_defaults_are_unity(self):
+        decoder = FullPolarizationDecoder({})
+
+        for wavelength in [5.0, 10.0, 16.0]:
+            assert decoder.a_0(wavelength) == pytest.approx(1.0)
+            assert decoder.a_pi(wavelength) == pytest.approx(1.0)
+
+    def test_encoding_matrix_shape(self):
+        config = {
+            "polarization": {
+                "polarizer": {"polarization": "0.9", "efficiency": "0.95"},
+                "analyzer": {"polarizationZero": "0.5", "polarizationPi": "0.25"},
+            }
+        }
+        decoder = FullPolarizationDecoder(config)
+
+        assert decoder.encoding_matrix(wavelength=6.0).shape == (4, 4)
+
+    def test_encoding_matrix_values_known_case(self):
+        config = {
+            "polarization": {
+                "polarizer": {"polarization": str(1.0 / 3.0), "efficiency": "1.0"},
+                "analyzer": {"polarizationZero": "0.5", "polarizationPi": "0.25"},
+            }
+        }
+        decoder = FullPolarizationDecoder(config)
+
+        expected = np.array(
+            [
+                [2.0 / 9.0, 4.0 / 9.0, 1.0 / 9.0, 2.0 / 9.0],
+                [1.0 / 9.0, 2.0 / 9.0, 2.0 / 9.0, 4.0 / 9.0],
+                [8.0 / 15.0, 2.0 / 15.0, 4.0 / 15.0, 1.0 / 15.0],
+                [4.0 / 15.0, 1.0 / 15.0, 8.0 / 15.0, 2.0 / 15.0],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(decoder.encoding_matrix(wavelength=6.0), expected)
+
+    def test_encoding_matrix_allows_perfect_polarizer(self):
+        config = {
+            "polarization": {
+                "polarizer": {"polarization": "1.0", "efficiency": "1.0"},
+                "analyzer": {"polarizationZero": "0.5", "polarizationPi": "0.25"},
+            }
+        }
+        decoder = FullPolarizationDecoder(config)
+
+        expected = np.array(
+            [
+                [1.0 / 3.0, 2.0 / 3.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0 / 3.0, 2.0 / 3.0],
+                [4.0 / 5.0, 1.0 / 5.0, 0.0, 0.0],
+                [0.0, 0.0, 4.0 / 5.0, 1.0 / 5.0],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(decoder.encoding_matrix(wavelength=6.0), expected)
+
+    @pytest.mark.parametrize(
+        "polarization_config, match",
+        [
+            ({"polarizer": {"polarization": "0"}}, "Polarizer polarization"),
+            ({"polarizer": {"efficiency": "1.1"}}, "Flipper efficiency"),
+            ({"analyzer": {"polarizationZero": "0"}}, "Analyzer zero-state polarization"),
+            ({"analyzer": {"polarizationPi": "0"}}, "Analyzer pi-state polarization"),
+        ],
+    )
+    def test_encoding_matrix_rejects_nonpositive_polarization(self, polarization_config, match):
+        config = {"polarization": polarization_config}
+        decoder = FullPolarizationDecoder(config)
+
+        with pytest.raises(ValueError, match=match):
+            decoder.encoding_matrix(wavelength=6.0)
+
+    def test_decode_returns_four_workspaces(self, full_pol_workspaces, clean_workspace):
+        device_cross_sections, _, config = full_pol_workspaces
+        decoder = FullPolarizationDecoder(config)
+
+        result = decoder.decode(device_cross_sections)
+        for ws in result:
+            clean_workspace(ws)
+
+        assert len(result) == 4
+
+    def test_decode_output_logs_have_polarization_state(self, full_pol_workspaces, clean_workspace):
+        device_cross_sections, _, config = full_pol_workspaces
+        decoder = FullPolarizationDecoder(config)
+
+        result = decoder.decode(device_cross_sections)
+        for ws in result:
+            clean_workspace(ws)
+
+        assert PolarizationState.get(result[0]) == PolarizationState.UP_UP
+        assert PolarizationState.get(result[1]) == PolarizationState.UP_DOWN
+        assert PolarizationState.get(result[2]) == PolarizationState.DOWN_UP
+        assert PolarizationState.get(result[3]) == PolarizationState.DOWN_DOWN
+        for ws in result:
+            assert PolarizationCrossSection.logname not in SampleLogs(ws)
+
+    def test_decode_wrong_count_raises(self, full_pol_workspaces):
+        device_cross_sections, _, config = full_pol_workspaces
+        decoder = FullPolarizationDecoder(config)
+
+        with pytest.raises(ValueError, match="exactly 4 device cross-sections"):
+            decoder.decode(device_cross_sections[:3])
+        with pytest.raises(ValueError, match="exactly 4 device cross-sections"):
+            decoder.decode(device_cross_sections + device_cross_sections)
+
+    def test_decode_order_invariant(self, full_pol_workspaces, clean_workspace):
+        device_cross_sections, _, config = full_pol_workspaces
+        decoder = FullPolarizationDecoder(config)
+
+        result_normal = decoder.decode(device_cross_sections)
+        result_reversed = decoder.decode(list(reversed(device_cross_sections)))
+        for ws in result_normal + result_reversed:
+            clean_workspace(ws)
+
+        for normal, reversed_ in zip(result_normal, result_reversed):
+            np.testing.assert_array_almost_equal(normal.readY(0), reversed_.readY(0))
+
+    def test_decode_intensity_known_case(self, full_pol_workspaces, clean_workspace):
+        device_cross_sections, spin_values, config = full_pol_workspaces
+        decoder = FullPolarizationDecoder(config)
+
+        result = decoder.decode(device_cross_sections)
+        for ws in result:
+            clean_workspace(ws)
+
+        for ws, expected in zip(result, spin_values):
+            np.testing.assert_array_almost_equal(ws.readY(0), [expected])
 
 
 if __name__ == "__main__":

--- a/tests/unit/drtsans/mono/gpsans/test_polarization.py
+++ b/tests/unit/drtsans/mono/gpsans/test_polarization.py
@@ -14,8 +14,6 @@ from drtsans.polarization import (
     PolarizationCrossSection,
     PolarizationState,
     polarized_sample,
-    _calc_flipping_ratio,
-    half_polarization,
     SimulatedPolarizationLogs,
     TimesGeneratorSpecs,
     PV_ANALYZER,
@@ -225,64 +223,6 @@ def test_polarized_sample(tmp_path):
         with pytest.raises(ValueError) as excinfo:
             polarized_sample(reduction_input)
         assert "Can't do polarization reduction on summed data sets" in str(excinfo.value)
-
-
-def test_flipping_ratio(temp_workspace_name, clean_workspace):
-    """Test for the calculation of the flipping ratio in section 9.1. This was used to determine
-    that the uncertainty needs to be calculated separately because of accumulation of numeric
-    error.
-
-    dev - Pete Peterson <petersonpf@ornl.gov>
-    SME - Lisa DeBeer-Schmitt <debeerschmlm@ornl.gov>
-          Mike Fitzsimmons <fitzsimmonsm@ornl.gov>
-    """
-    # this is called "P" in the document
-    polarization = CreateSingleValuedWorkspace(DataValue=0.95, ErrorValue=0.01, OutputWorkspace=temp_workspace_name())
-    flipping_ratio_expected = (1.0 + 0.95) / (1.0 - 0.95)
-    flipping_ratio_err_expected = (2.0 * polarization.readE(0)[0]) / 0.0025  # denominator is (1-p)^2
-
-    flipping_ratio = _calc_flipping_ratio(polarization)
-    clean_workspace(flipping_ratio)
-
-    assert flipping_ratio.extractY() == flipping_ratio_expected
-    assert flipping_ratio.extractE() == pytest.approx(flipping_ratio_err_expected)
-
-
-def test_half_polarization(temp_workspace_name):
-    """Test the calculation and application of the half polarization from section 9.1
-    and requires reading section 9.0 for definition variables.
-
-    dev - Pete Peterson <petersonpf@ornl.gov>
-    SME - Lisa DeBeer-Schmitt <debeerschmlm@ornl.gov>
-          Mike Fitzsimmons <fitzsimmonsm@ornl.gov>
-    """
-    # this is called "P" in the document
-    polarization = CreateSingleValuedWorkspace(DataValue=0.95, ErrorValue=0.01, OutputWorkspace=temp_workspace_name())
-    # this is called "e" in the document
-    efficiency = CreateSingleValuedWorkspace(DataValue=0.998, ErrorValue=0.001, OutputWorkspace=temp_workspace_name())
-
-    # values for the measured flipper off (M0) and flipper on (M1)
-    M0 = CreateSingleValuedWorkspace(DataValue=10000, ErrorValue=100, OutputWorkspace=temp_workspace_name())
-    M1 = CreateSingleValuedWorkspace(DataValue=8100, ErrorValue=90, OutputWorkspace=temp_workspace_name())
-
-    # expected results
-    SpinUpExp = CreateSingleValuedWorkspace(
-        DataValue=10050.100,
-        ErrorValue=103.2046,
-        OutputWorkspace=temp_workspace_name(),  # was 103.205
-    )
-    SpinDownExp = CreateSingleValuedWorkspace(
-        DataValue=8046.0925, ErrorValue=93.2163, OutputWorkspace=temp_workspace_name()
-    )
-
-    # do the calculation
-    SpinUp, SpinDown = half_polarization(M0, M1, polarization, efficiency)
-
-    # compare with what was expected
-    assert SpinUp.extractY()[0][0] == pytest.approx(SpinUpExp.extractY()[0][0])
-    assert SpinUp.extractE()[0][0] == pytest.approx(SpinUpExp.extractE()[0][0])
-    assert SpinDown.extractY()[0][0] == pytest.approx(SpinDownExp.extractY()[0][0])
-    assert SpinDown.extractE()[0][0] == pytest.approx(SpinDownExp.extractE()[0][0])
 
 
 class TestSimulatedLogs:

--- a/tests/unit/drtsans/mono/gpsans/test_polarization.py
+++ b/tests/unit/drtsans/mono/gpsans/test_polarization.py
@@ -169,18 +169,38 @@ def test_polarized_sample(tmp_path):
         with h5py.File(nexus_file, "a") as write_handle:
             group = write_handle.require_group(f"/entry/DASlogs/{PV_POLARIZER}")
             group.create_dataset("value", data=1)
-        reduction_input["configuration"]["polarization"] = {"extra_key": "extra_value"}  # clear "level""
+        # "level" is unset (must be auto-detected) but polarizer calibration values are present
+        reduction_input["configuration"]["polarization"] = {
+            "polarizer": {"polarization": "0.9", "efficiency": "0.95"},
+        }
         assert polarized_sample(reduction_input) is True
         assert reduction_input["configuration"]["polarization"]["level"] == "half"
-        assert "extra_key" not in reduction_input["configuration"]["polarization"]  # deleted obsolete key
+        # regression: polarizer calibration values must survive the level auto-detection
+        assert reduction_input["configuration"]["polarization"]["polarizer"] == {
+            "polarization": "0.9",
+            "efficiency": "0.95",
+        }
 
         # case: single sample run with full polarization
         with h5py.File(nexus_file, "a") as write_handle:
             group = write_handle.require_group(f"/entry/DASlogs/{PV_ANALYZER}")
             group.create_dataset("value", data=1)
-        reduction_input["configuration"]["polarization"] = {}  # clear the polarization entry
+        # "level" is unset (must be auto-detected) but polarizer/analyzer calibration values are present
+        reduction_input["configuration"]["polarization"] = {
+            "polarizer": {"polarization": "0.9", "efficiency": "0.95"},
+            "analyzer": {"polarizationZero": "0.8", "polarizationPi": "-0.7"},
+        }
         assert polarized_sample(reduction_input) is True
         assert reduction_input["configuration"]["polarization"]["level"] == "full"
+        # regression: polarizer/analyzer calibration values must survive the level auto-detection
+        assert reduction_input["configuration"]["polarization"]["polarizer"] == {
+            "polarization": "0.9",
+            "efficiency": "0.95",
+        }
+        assert reduction_input["configuration"]["polarization"]["analyzer"] == {
+            "polarizationZero": "0.8",
+            "polarizationPi": "-0.7",
+        }
 
         # case: multiple sample runs when all are unpolarized
         for run_num in ["12349", "12350", "12351"]:

--- a/tests/unit/drtsans/mono/gpsans/test_polarization.py
+++ b/tests/unit/drtsans/mono/gpsans/test_polarization.py
@@ -459,6 +459,24 @@ class TestPolarizationDecoder:
         with pytest.raises(NotImplementedError):
             PolarizationDecoder({}).decode([])
 
+    @pytest.mark.parametrize("value", [-1.0, 0.0, 1.0])
+    def test_polarization_interval_includes_signed_bounds(self, value):
+        PolarizationDecoder._validate_polarization_interval("Polarization", value)
+
+    @pytest.mark.parametrize("value", [-1.1, 1.1])
+    def test_polarization_interval_rejects_outside_signed_bounds(self, value):
+        with pytest.raises(ValueError, match=r"Polarization must be in the interval \[-1, 1\]"):
+            PolarizationDecoder._validate_polarization_interval("Polarization", value)
+
+    @pytest.mark.parametrize("value", [0.0, 1.0])
+    def test_efficiency_interval_includes_bounds(self, value):
+        PolarizationDecoder._validate_efficiency_interval("Flipper efficiency", value)
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_efficiency_interval_rejects_outside_unit_bounds(self, value):
+        with pytest.raises(ValueError, match=r"Flipper efficiency must be in the interval \[0, 1\]"):
+            PolarizationDecoder._validate_efficiency_interval("Flipper efficiency", value)
+
 
 class TestHalfPolarizationDecoder:
     def _make_decoder(self, polarization, efficiency):
@@ -483,13 +501,13 @@ class TestHalfPolarizationDecoder:
         M = decoder.decoding_matrix(wavelength=6.0)
         np.testing.assert_array_almost_equal(M, [[2, -1], [-1, 2]])
 
-    def test_zero_polarization_raises(self):
-        decoder = self._make_decoder(polarization=0.0, efficiency=1.0)
+    def test_polarization_below_negative_one_raises(self):
+        decoder = self._make_decoder(polarization=-1.1, efficiency=1.0)
         with pytest.raises(ValueError, match="Polarization must be in the interval"):
             decoder.decoding_matrix(wavelength=6.0)
 
-    def test_zero_efficiency_raises(self):
-        decoder = self._make_decoder(polarization=0.9, efficiency=0.0)
+    def test_efficiency_below_zero_raises(self):
+        decoder = self._make_decoder(polarization=0.9, efficiency=-0.1)
         with pytest.raises(ValueError, match="Flipper efficiency must be in the interval"):
             decoder.decoding_matrix(wavelength=6.0)
 
@@ -497,6 +515,10 @@ class TestHalfPolarizationDecoder:
         decoder = self._make_decoder(polarization=0.9, efficiency=1.1)
         with pytest.raises(ValueError, match="Flipper efficiency must be in the interval"):
             decoder.decoding_matrix(wavelength=6.0)
+
+    def test_negative_polarization_is_in_valid_range(self):
+        decoder = self._make_decoder(polarization=-0.5, efficiency=0.8)
+        assert decoder.decoding_matrix(wavelength=6.0).shape == (2, 2)
 
     def test_matrix_inverts_encoding(self):
         """Decoding matrix M_dec is the inverse of the physical encoding matrix M_enc."""
@@ -594,8 +616,8 @@ class TestFullPolarizationDecoder:
 
         assert decoder.p(6.0) == pytest.approx(0.9)
         assert decoder.e(6.0) == pytest.approx(0.8)
-        assert decoder.a_0(6.0) == pytest.approx(0.7)
-        assert decoder.a_pi(6.0) == pytest.approx(0.6)
+        assert decoder.p_0(6.0) == pytest.approx(0.7)
+        assert decoder.p_pi(6.0) == pytest.approx(0.6)
 
     def test_loads_wavelength_dependent_analyzer_values(self):
         config = {
@@ -608,17 +630,17 @@ class TestFullPolarizationDecoder:
         }
         decoder = FullPolarizationDecoder(config)
 
-        assert decoder.a_0(16.0) == pytest.approx(0.95)
-        assert decoder.a_0(6.0) == pytest.approx(0.95 - 0.01 * (6.0 - 16.0))
-        assert decoder.a_pi(16.0) == pytest.approx(0.90)
-        assert decoder.a_pi(6.0) == pytest.approx(0.90 - 0.02 * (6.0 - 16.0))
+        assert decoder.p_0(16.0) == pytest.approx(0.95)
+        assert decoder.p_0(6.0) == pytest.approx(0.95 - 0.01 * (6.0 - 16.0))
+        assert decoder.p_pi(16.0) == pytest.approx(0.90)
+        assert decoder.p_pi(6.0) == pytest.approx(0.90 - 0.02 * (6.0 - 16.0))
 
-    def test_analyzer_defaults_are_unity(self):
+    def test_analyzer_defaults_select_ideal_opposite_states(self):
         decoder = FullPolarizationDecoder({})
 
         for wavelength in [5.0, 10.0, 16.0]:
-            assert decoder.a_0(wavelength) == pytest.approx(1.0)
-            assert decoder.a_pi(wavelength) == pytest.approx(1.0)
+            assert decoder.p_0(wavelength) == pytest.approx(1.0)
+            assert decoder.p_pi(wavelength) == pytest.approx(-1.0)
 
     def test_encoding_matrix_shape(self):
         config = {
@@ -642,10 +664,10 @@ class TestFullPolarizationDecoder:
 
         expected = np.array(
             [
-                [2.0 / 9.0, 4.0 / 9.0, 1.0 / 9.0, 2.0 / 9.0],
-                [1.0 / 9.0, 2.0 / 9.0, 2.0 / 9.0, 4.0 / 9.0],
-                [8.0 / 15.0, 2.0 / 15.0, 4.0 / 15.0, 1.0 / 15.0],
-                [4.0 / 15.0, 1.0 / 15.0, 8.0 / 15.0, 2.0 / 15.0],
+                [1.0 / 2.0, 1.0 / 6.0, 1.0 / 4.0, 1.0 / 12.0],
+                [1.0 / 4.0, 1.0 / 12.0, 1.0 / 2.0, 1.0 / 6.0],
+                [5.0 / 12.0, 1.0 / 4.0, 5.0 / 24.0, 1.0 / 8.0],
+                [5.0 / 24.0, 1.0 / 8.0, 5.0 / 12.0, 1.0 / 4.0],
             ]
         )
 
@@ -662,25 +684,54 @@ class TestFullPolarizationDecoder:
 
         expected = np.array(
             [
-                [1.0 / 3.0, 2.0 / 3.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0 / 3.0, 2.0 / 3.0],
-                [4.0 / 5.0, 1.0 / 5.0, 0.0, 0.0],
-                [0.0, 0.0, 4.0 / 5.0, 1.0 / 5.0],
+                [3.0 / 4.0, 1.0 / 4.0, 0.0, 0.0],
+                [0.0, 0.0, 3.0 / 4.0, 1.0 / 4.0],
+                [5.0 / 8.0, 3.0 / 8.0, 0.0, 0.0],
+                [0.0, 0.0, 5.0 / 8.0, 3.0 / 8.0],
             ]
         )
 
         np.testing.assert_array_almost_equal(decoder.encoding_matrix(wavelength=6.0), expected)
 
+    def test_encoding_matrix_defaults_are_finite_and_select_distinct_spin_states(self):
+        decoder = FullPolarizationDecoder({})
+
+        expected = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(decoder.encoding_matrix(wavelength=6.0), expected)
+
+    def test_encoding_matrix_allows_signed_polarization_values(self):
+        config = {
+            "polarization": {
+                "polarizer": {"polarization": "-0.5", "efficiency": "0.8"},
+                "analyzer": {"polarizationZero": "0", "polarizationPi": "-0.25"},
+            }
+        }
+        decoder = FullPolarizationDecoder(config)
+
+        matrix = decoder.encoding_matrix(wavelength=6.0)
+        assert matrix.shape == (4, 4)
+        assert np.all(np.isfinite(matrix))
+
     @pytest.mark.parametrize(
         "polarization_config, match",
         [
-            ({"polarizer": {"polarization": "0"}}, "Polarizer polarization"),
+            ({"polarizer": {"polarization": "-1.1"}}, "Polarizer polarization"),
+            ({"polarizer": {"polarization": "1.1"}}, "Polarizer polarization"),
+            ({"polarizer": {"efficiency": "-0.1"}}, "Flipper efficiency"),
             ({"polarizer": {"efficiency": "1.1"}}, "Flipper efficiency"),
-            ({"analyzer": {"polarizationZero": "0"}}, "Analyzer zero-state polarization"),
-            ({"analyzer": {"polarizationPi": "0"}}, "Analyzer pi-state polarization"),
+            ({"analyzer": {"polarizationZero": "-1.1"}}, "Analyzer zero-state polarization"),
+            ({"analyzer": {"polarizationPi": "1.1"}}, "Analyzer pi-state polarization"),
         ],
     )
-    def test_encoding_matrix_rejects_nonpositive_polarization(self, polarization_config, match):
+    def test_encoding_matrix_rejects_out_of_range_values(self, polarization_config, match):
         config = {"polarization": polarization_config}
         decoder = FullPolarizationDecoder(config)
 

--- a/tests/unit/drtsans/mono/gpsans/test_polarization.py
+++ b/tests/unit/drtsans/mono/gpsans/test_polarization.py
@@ -1,11 +1,14 @@
 import h5py
+import numpy as np
 from mantid.kernel import amend_config
-from mantid.simpleapi import CreateSingleValuedWorkspace, mtd
+from mantid.simpleapi import CreateSingleValuedWorkspace, CreateWorkspace, DeleteWorkspace, mtd
 from numpy.testing import assert_equal, assert_array_almost_equal
 import pytest
 
 from drtsans.instruments import empty_instrument_workspace
 from drtsans.polarization import (
+    HalfPolarizationDecoder,
+    PolarizationDecoder,
     PolarizationLevel,
     PolarizationCrossSection,
     PolarizationState,
@@ -370,6 +373,173 @@ class TestSimulatedLogs:
         assert "T00:04:59.5" in str(sample_logs[PV_POLARIZER_VETO].times[-1])
         assert "T00:04:00.0" in str(sample_logs[PV_ANALYZER_FLIPPER].times[-1])
         assert (PV_ANALYZER_VETO in sample_logs) is False
+
+
+@pytest.fixture
+def half_pol_workspaces():
+    """Two Workspace2D objects tagged with OFF/ON cross-section logs and wavelength=6."""
+    names, ws_list = [], []
+    for cross_section, y_val in [
+        (PolarizationCrossSection.OFF, 10.0),
+        (PolarizationCrossSection.ON, 8.0),
+    ]:
+        name = mtd.unique_hidden_name()
+        ws = CreateWorkspace(DataX=[5.0, 7.0], DataY=[y_val], DataE=[0.1], OutputWorkspace=name)
+        SampleLogs(ws).insert("wavelength", 6.0)
+        cross_section.log(ws)
+        names.append(name)
+        ws_list.append(ws)
+    yield ws_list
+    for name in names:
+        if mtd.doesExist(name):
+            DeleteWorkspace(name)
+
+
+class TestPolarizationDecoder:
+    def test_constant_polarization_and_efficiency(self):
+        config = {"polarization": {"polarizer": {"polarization": "0.9", "efficiency": "0.8"}}}
+        decoder = PolarizationDecoder(config)
+        assert decoder.p(6.0) == pytest.approx(0.9)
+        assert decoder.e(6.0) == pytest.approx(0.8)
+
+    def test_linear_polarization(self):
+        config = {"polarization": {"polarizer": {"polarization": "0.95 - 0.01*(x - 16)", "efficiency": "1"}}}
+        decoder = PolarizationDecoder(config)
+        assert decoder.p(16.0) == pytest.approx(0.95)
+        assert decoder.p(6.0) == pytest.approx(0.95 - 0.01 * (6.0 - 16.0))
+
+    def test_numeric_value_coercion(self):
+        config = {"polarization": {"polarizer": {"polarization": 0.9, "efficiency": 0.8}}}
+        decoder = PolarizationDecoder(config)
+        assert decoder.p(10.0) == pytest.approx(0.9)
+        assert decoder.e(10.0) == pytest.approx(0.8)
+
+    def test_defaults_are_unity(self):
+        decoder = PolarizationDecoder({})
+        for wavelength in [5.0, 10.0, 16.0]:
+            assert decoder.p(wavelength) == pytest.approx(1.0)
+            assert decoder.e(wavelength) == pytest.approx(1.0)
+
+    def test_decode_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            PolarizationDecoder({}).decode([])
+
+
+class TestHalfPolarizationDecoder:
+    def _make_decoder(self, polarization, efficiency):
+        config = {"polarization": {"polarizer": {"polarization": str(polarization), "efficiency": str(efficiency)}}}
+        return HalfPolarizationDecoder(config)
+
+    # --- Group A: decoding_matrix (pure numpy) ---
+
+    def test_identity_at_perfect_polarization(self):
+        """P=1, e=1 → perfect instrument → decoding matrix is the identity."""
+        decoder = self._make_decoder(polarization=1.0, efficiency=1.0)
+        M = decoder.decoding_matrix(wavelength=6.0)
+        np.testing.assert_array_almost_equal(M, np.eye(2))
+
+    def test_matrix_shape(self):
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.95)
+        assert decoder.decoding_matrix(wavelength=6.0).shape == (2, 2)
+
+    def test_matrix_values_known_case(self):
+        """P=1/3, e=1 → dl=1, ul=2 → M = [[2,-1],[-1,2]]."""
+        decoder = self._make_decoder(polarization=1.0 / 3.0, efficiency=1.0)
+        M = decoder.decoding_matrix(wavelength=6.0)
+        np.testing.assert_array_almost_equal(M, [[2, -1], [-1, 2]])
+
+    def test_zero_polarization_raises(self):
+        decoder = self._make_decoder(polarization=0.0, efficiency=1.0)
+        with pytest.raises(ValueError, match="Polarization must be greater than zero"):
+            decoder.decoding_matrix(wavelength=6.0)
+
+    def test_zero_efficiency_raises(self):
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.0)
+        with pytest.raises(ValueError, match="Flipper efficiency must be greater than zero"):
+            decoder.decoding_matrix(wavelength=6.0)
+
+    def test_matrix_inverts_encoding(self):
+        """Decoding matrix M_dec is the inverse of the physical encoding matrix M_enc."""
+
+        def encoding_matrix(p, e):
+            # Row 0: flipper off — fraction of S↑ and S↓ that pass the polarizer
+            # Row 1: flipper on  — flipper flips spin with efficiency e before analysis
+            return np.array(
+                [
+                    [(1 + p) / 2, (1 - p) / 2],
+                    [
+                        (1 - e) * (1 + p) / 2 + e * (1 - p) / 2,
+                        (1 - e) * (1 - p) / 2 + e * (1 + p) / 2,
+                    ],
+                ]
+            )
+
+        for p, e in [(0.9, 0.95), (0.5, 0.8), (1.0 / 3.0, 1.0), (0.95, 0.998)]:
+            decoder = self._make_decoder(polarization=p, efficiency=e)
+            M_dec = decoder.decoding_matrix(wavelength=6.0)
+            M_enc = encoding_matrix(p, e)
+            np.testing.assert_array_almost_equal(M_dec @ M_enc, np.eye(2), decimal=10)
+
+    # --- Group B: decode (Mantid workspaces) ---
+
+    def test_returns_two_workspaces(self, half_pol_workspaces, clean_workspace):
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.95)
+        result = decoder.decode(half_pol_workspaces)
+        for ws in result:
+            clean_workspace(ws)
+        assert len(result) == 2
+
+    def test_output_logs_have_polarization_state(self, half_pol_workspaces, clean_workspace):
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.95)
+        result = decoder.decode(half_pol_workspaces)
+        for ws in result:
+            clean_workspace(ws)
+        assert PolarizationState.get(result[0]) == PolarizationState.UP
+        assert PolarizationState.get(result[1]) == PolarizationState.DOWN
+
+    def test_output_logs_lack_cross_section(self, half_pol_workspaces, clean_workspace):
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.95)
+        result = decoder.decode(half_pol_workspaces)
+        for ws in result:
+            clean_workspace(ws)
+        for ws in result:
+            assert PolarizationCrossSection.logname not in SampleLogs(ws)
+
+    def test_wrong_count_raises(self, half_pol_workspaces):
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.95)
+        with pytest.raises(ValueError, match="exactly 2 device cross-sections"):
+            decoder.decode([half_pol_workspaces[0]])
+        with pytest.raises(ValueError, match="exactly 2 device cross-sections"):
+            decoder.decode(half_pol_workspaces + half_pol_workspaces)
+
+    def test_order_invariant(self, half_pol_workspaces, clean_workspace):
+        """Passing [s0, s1] or [s1, s0] yields the same decoded spin states."""
+        decoder = self._make_decoder(polarization=0.9, efficiency=0.95)
+        result_normal = decoder.decode(half_pol_workspaces)
+        result_reversed = decoder.decode(list(reversed(half_pol_workspaces)))
+        for ws in result_normal + result_reversed:
+            clean_workspace(ws)
+        np.testing.assert_array_almost_equal(result_normal[0].readY(0), result_reversed[0].readY(0))
+        np.testing.assert_array_almost_equal(result_normal[1].readY(0), result_reversed[1].readY(0))
+
+    def test_intensity_at_perfect_polarization(self, half_pol_workspaces, clean_workspace):
+        """P=1, e=1: identity decoding → S↑ = S⁰ and S↓ = S¹."""
+        decoder = self._make_decoder(polarization=1.0, efficiency=1.0)
+        ws_off, ws_on = half_pol_workspaces
+        result = decoder.decode(half_pol_workspaces)
+        for ws in result:
+            clean_workspace(ws)
+        np.testing.assert_array_almost_equal(result[0].readY(0), ws_off.readY(0))
+        np.testing.assert_array_almost_equal(result[1].readY(0), ws_on.readY(0))
+
+    def test_intensity_known_case(self, half_pol_workspaces, clean_workspace):
+        """P=1/3, e=1: M=[[2,-1],[-1,2]] → S↑=2*10-8=12, S↓=-10+2*8=6."""
+        decoder = self._make_decoder(polarization=1.0 / 3.0, efficiency=1.0)
+        result = decoder.decode(half_pol_workspaces)
+        for ws in result:
+            clean_workspace(ws)
+        np.testing.assert_array_almost_equal(result[0].readY(0), [12.0])
+        np.testing.assert_array_almost_equal(result[1].readY(0), [6.0])
 
 
 if __name__ == "__main__":

--- a/tests/unit/drtsans/test_plotting.py
+++ b/tests/unit/drtsans/test_plotting.py
@@ -68,6 +68,24 @@ def test_IQmod(backend, filename):
     fileCheckAndRemove(filename)
 
 
+def test_IQmod_close_figures_option():
+    """Test that plot_IQmod keeps or closes pyplot figures as requested."""
+    plt.close("all")
+    x = np.linspace(1.0, 2.0, 5)
+    data = IQmod(intensity=x, error=np.ones_like(x), mod_q=x)
+
+    retained_filename = "test_IQmod_retained.png"
+    plot_IQmod([data], filename=retained_filename, backend="mpl")
+    assert plt.get_fignums()
+    plt.close("all")
+    fileCheckAndRemove(retained_filename)
+
+    closed_filename = "test_IQmod_closed.png"
+    plot_IQmod([data], filename=closed_filename, backend="mpl", close_figures=True)
+    assert plt.get_fignums() == []
+    fileCheckAndRemove(closed_filename)
+
+
 @pytest.mark.parametrize(
     "backend, filename",
     [("mpl", "test_IQmod_multi.png"), ("d3", "test_IQmod_multi.json")],

--- a/tests/unit/drtsans/test_redparams.py
+++ b/tests/unit/drtsans/test_redparams.py
@@ -723,6 +723,12 @@ class TestReductionParametersGPSANS:
         )
         reduction_parameters(parameters_new, permissible=True)
 
+    def test_polarization_defaults(self):
+        assert self.parameters_all["configuration"]["polarization"] == {
+            "polarizer": {"polarization": "1", "efficiency": "1"},
+            "analyzer": {"polarizationZero": "1", "polarizationPi": "1"},
+        }
+
 
 class TestReductionParametersBIOSANS:
     parameters_common = {

--- a/tests/unit/drtsans/test_redparams.py
+++ b/tests/unit/drtsans/test_redparams.py
@@ -726,7 +726,7 @@ class TestReductionParametersGPSANS:
     def test_polarization_defaults(self):
         assert self.parameters_all["configuration"]["polarization"] == {
             "polarizer": {"polarization": "1", "efficiency": "1"},
-            "analyzer": {"polarizationZero": "1", "polarizationPi": "1"},
+            "analyzer": {"polarizationZero": "1", "polarizationPi": "-1"},
         }
 
 


### PR DESCRIPTION
## Description of work:

Polarization “conversion” with decoders that transform measured device cross-sections into physical spin-state cross-sections.
Add explicit `close_figures` option to control matplotlib figure lifetime. This prevent too much memory consumption when keeping the figures is not required.

**Changes:**
- Added polarization decoders (half/full) supporting wavelength-dependent polarization/efficiency specified as expressions.
- Updated spin-filter event splitting/logging to use standardized lowercase cross-section labels and the shared cross-section log key.
- Added `close_figures` support across plotting helpers and updated callers/tests accordingly.

**Check all that apply:**
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Added unit tests
- [x] Added integration tests
- [ ] Included a manual test for the reviewer
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [11552](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11552)


## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
