### PR TITLE
Fix EQSANS frame-labeled PNG output names

### DIFF
--- a/docs/user/slicing.rst
+++ b/docs/user/slicing.rst
@@ -8,7 +8,7 @@ reduction is performed separately on each slice according to the specified reduc
 The output files will have a slice index appended to the configured ``"outputFileName"``, e.g.
 ``myFileName_0_Iq.dat``, ``myFileName_1_Iq.dat``, etc.
 
-For EQSANS run in frame skip mode, each frame will have their own time slices.
+For EQSANS run in frame-skip mode, each frame will have its own time slices.
 Thus, output files will also contain the frame index, e.g.
 ``myFileName_0_frame_0_Iq.dat`` and ``myFileName_0_frame_1_Iq.dat``.
 If wedge binning is selected, the wedge label appears between the slice and frame labels,

--- a/docs/user/slicing.rst
+++ b/docs/user/slicing.rst
@@ -8,6 +8,13 @@ reduction is performed separately on each slice according to the specified reduc
 The output files will have a slice index appended to the configured ``"outputFileName"``, e.g.
 ``myFileName_0_Iq.dat``, ``myFileName_1_Iq.dat``, etc.
 
+For EQSANS run in frame skip mode, each frame will have their own time slices.
+Thus, output files will also contain the frame index, e.g.
+``myFileName_0_frame_0_Iq.dat`` and ``myFileName_0_frame_1_Iq.dat``.
+If wedge binning is selected, the wedge label appears between the slice and frame labels,
+e.g. ``myFileName_0_wedge_0_frame_0_Iq.dat``. PNG plot filenames follow the
+same convention as the corresponding reduced data files.
+
 Time Slicing
 ------------
 

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -81,7 +81,11 @@ __all__ = [
     "plot_reduction_output",
 ]
 
-I_output = namedtuple("I_output", ["I2D_main", "I1D_main"])
+I_output = namedtuple(
+    "I_output",
+    ["I2D_main", "I1D_main", "slice_label", "frame_label"],
+    defaults=("", ""),
+)
 
 
 def _get_configuration_file_parameters(sample_run, directory=None):
@@ -682,7 +686,7 @@ def reduce_single_configuration(
     Returns
     -------
     ~list
-        list of I_output: ['I2D_main', 'I1D_main']
+        list of I_output: ['I2D_main', 'I1D_main', 'slice_label', 'frame_label']
 
     """
     # Process reduction input: configuration and etc.
@@ -1045,7 +1049,12 @@ def reduce_single_configuration(
                 )
                 save_i1d(i1d_main_out[j], f"{ascii_1D_filename}.dat", skip_nan=skip_nan)
 
-            current_output = I_output(I2D_main=iq2d_main_out, I1D_main=i1d_main_out)
+            current_output = I_output(
+                I2D_main=iq2d_main_out,
+                I1D_main=i1d_main_out,
+                slice_label=output_suffix,
+                frame_label=fr_label,
+            )
             output.append(current_output)
         # END binning loop over frame
 
@@ -1185,19 +1194,28 @@ def parse_auto_wedge_setup(reduction_config: Dict, bin1d_type: str, wedges_min) 
     return autoWedgeOpts, symmetric_wedges
 
 
-def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None, close_figures=True):
+def plot_reduction_output(
+    reduction_output: List[I_output],
+    reduction_input: dict,
+    imshow_kwargs: Optional[dict] = None,
+    close_figures: bool = True,
+) -> None:
+    """Save PNG plots for EQSANS reduction output.
+
+    Filenames use the slice and frame labels generated with the reduced data so
+    PNG names stay synchronized with the corresponding ASCII and NXcanSAS files.
+    """
     reduction_config = reduction_input["configuration"]
     output_dir = reduction_config["outputDir"]
     outputFilename = reduction_input["outputFileName"]
-    output_suffix = ""
 
     bin1d_type = reduction_config["1DQbinType"]
 
     if imshow_kwargs is None:
         imshow_kwargs = {}
     for i, out in enumerate(reduction_output):
-        if len(reduction_output) > 1:
-            output_suffix = f"_{i}"
+        slice_label = getattr(out, "slice_label", f"_{i}" if len(reduction_output) > 1 else "")
+        frame_label = getattr(out, "frame_label", "")
 
         wedges = reduction_config["wedges"] if bin1d_type == "wedge" else None
         symmetric_wedges = reduction_config.get("symmetric_wedges", True)
@@ -1205,7 +1223,7 @@ def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None,
         qmin = reduction_config["Qmin"]
         qmax = reduction_config["Qmax"]
 
-        filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}_Iqxqy.png")
+        filename = os.path.join(output_dir, f"{outputFilename}{slice_label}{frame_label}_Iqxqy.png")
         plot_IQazimuthal(
             out.I2D_main,
             filename,
@@ -1225,7 +1243,10 @@ def plot_reduction_output(reduction_output, reduction_input, imshow_kwargs=None,
             add_suffix = ""
             if len(out.I1D_main) > 1:
                 add_suffix = f"_wedge_{j}"
-            filename = os.path.join(output_dir, f"{outputFilename}{output_suffix}{add_suffix}_{binning_suffix}.png")
+            filename = os.path.join(
+                output_dir,
+                f"{outputFilename}{slice_label}{add_suffix}{frame_label}_{binning_suffix}.png",
+            )
             plot_i1d(
                 [out.I1D_main[j]],
                 filename,

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -1214,7 +1214,7 @@ def plot_reduction_output(
     if imshow_kwargs is None:
         imshow_kwargs = {}
     for i, out in enumerate(reduction_output):
-        slice_label = getattr(out, "slice_label", f"_{i}" if len(reduction_output) > 1 else "")
+        slice_label = getattr(out, "slice_label", "") or (f"_{i}" if len(reduction_output) > 1 else "")
         frame_label = getattr(out, "frame_label", "")
 
         wedges = reduction_config["wedges"] if bin1d_type == "wedge" else None

--- a/tests/unit/drtsans/tof/eqsans/test_api.py
+++ b/tests/unit/drtsans/tof/eqsans/test_api.py
@@ -425,6 +425,26 @@ def test_plot_reduction_output(mock_plot_IQazimuthal, mock_plot_i1d, mock_allow_
     assert [call.args[1] for call in mock_plot_i1d.call_args_list] == ["/tmp/test_Iq.png"]
     mock_allow_overwrite.assert_called_once_with("/tmp")
 
+    mock_plot_IQazimuthal.reset_mock()
+    mock_plot_i1d.reset_mock()
+    mock_allow_overwrite.reset_mock()
+
+    reduction_output = [
+        I_output(I2D_main="2d-slice0", I1D_main=["1d-slice0"]),
+        I_output(I2D_main="2d-slice1", I1D_main=["1d-slice1"]),
+    ]
+    plot_reduction_output(reduction_output, reduction_input, close_figures=False)
+
+    assert [call.args[1] for call in mock_plot_IQazimuthal.call_args_list] == [
+        "/tmp/test_0_Iqxqy.png",
+        "/tmp/test_1_Iqxqy.png",
+    ]
+    assert [call.args[1] for call in mock_plot_i1d.call_args_list] == [
+        "/tmp/test_0_Iq.png",
+        "/tmp/test_1_Iq.png",
+    ]
+    mock_allow_overwrite.assert_called_once_with("/tmp")
+
 
 @mock.patch("drtsans.tof.eqsans.api.plotly_IQazimuthal")
 @mock.patch("drtsans.tof.eqsans.api.plotly_i1d")

--- a/tests/unit/drtsans/tof/eqsans/test_api.py
+++ b/tests/unit/drtsans/tof/eqsans/test_api.py
@@ -9,8 +9,10 @@ import pytest
 
 from drtsans.tof.eqsans import reduction_parameters
 from drtsans.tof.eqsans.api import (
+    I_output,
     load_all_files,
     prepare_data_workspaces,
+    plot_reduction_output,
     plotly_reduction_output,
     pre_process_single_configuration,
 )
@@ -356,6 +358,72 @@ def test_process_single_configuration_thickness_absolute_scale(generic_workspace
         thickness=0.1,
     )
     assert_equal(output.extractY(), [[15], [30], [45], [60]])
+
+
+@mock.patch("drtsans.tof.eqsans.api.allow_overwrite")
+@mock.patch("drtsans.tof.eqsans.api.plot_i1d")
+@mock.patch("drtsans.tof.eqsans.api.plot_IQazimuthal")
+def test_plot_reduction_output(mock_plot_IQazimuthal, mock_plot_i1d, mock_allow_overwrite):
+    """Test that plot_reduction_output uses slice and frame labels in output filenames."""
+    reduction_input = {
+        "outputFileName": "test",
+        "configuration": {
+            "outputDir": "/tmp",
+            "1DQbinType": "wedge",
+            "wedges": None,
+            "symmetric_wedges": True,
+            "Qmin": None,
+            "Qmax": None,
+        },
+    }
+    reduction_output = [
+        I_output(
+            I2D_main="2d-slice0-frame0",
+            I1D_main=["1d-wedge0", "1d-wedge1"],
+            slice_label="_0",
+            frame_label="_frame_0",
+        ),
+        I_output(
+            I2D_main="2d-slice0-frame1",
+            I1D_main=["1d-wedge0", "1d-wedge1"],
+            slice_label="_0",
+            frame_label="_frame_1",
+        ),
+        I_output(
+            I2D_main="2d-slice1-frame0",
+            I1D_main=["1d-wedge0", "1d-wedge1"],
+            slice_label="_1",
+            frame_label="_frame_0",
+        ),
+    ]
+
+    plot_reduction_output(reduction_output, reduction_input, close_figures=False)
+
+    assert [call.args[1] for call in mock_plot_IQazimuthal.call_args_list] == [
+        "/tmp/test_0_frame_0_Iqxqy.png",
+        "/tmp/test_0_frame_1_Iqxqy.png",
+        "/tmp/test_1_frame_0_Iqxqy.png",
+    ]
+    assert [call.args[1] for call in mock_plot_i1d.call_args_list] == [
+        "/tmp/test_0_wedge_0_frame_0_Iq.png",
+        "/tmp/test_0_wedge_1_frame_0_Iq.png",
+        "/tmp/test_0_wedge_0_frame_1_Iq.png",
+        "/tmp/test_0_wedge_1_frame_1_Iq.png",
+        "/tmp/test_1_wedge_0_frame_0_Iq.png",
+        "/tmp/test_1_wedge_1_frame_0_Iq.png",
+    ]
+    mock_allow_overwrite.assert_called_once_with("/tmp")
+
+    mock_plot_IQazimuthal.reset_mock()
+    mock_plot_i1d.reset_mock()
+    mock_allow_overwrite.reset_mock()
+    reduction_input["configuration"]["1DQbinType"] = "scalar"
+
+    plot_reduction_output([I_output(I2D_main="2d", I1D_main=["1d"])], reduction_input, close_figures=False)
+
+    assert [call.args[1] for call in mock_plot_IQazimuthal.call_args_list] == ["/tmp/test_Iqxqy.png"]
+    assert [call.args[1] for call in mock_plot_i1d.call_args_list] == ["/tmp/test_Iq.png"]
+    mock_allow_overwrite.assert_called_once_with("/tmp")
 
 
 @mock.patch("drtsans.tof.eqsans.api.plotly_IQazimuthal")


### PR DESCRIPTION
## Description of work:

**Check all that apply:**
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~Added integration tests~
- [ ] ~Included a manual test for the reviewer~
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [16491](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16491)

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
