### PR TITLE
Refactor elastic correction workflow

### DIFF
--- a/src/drtsans/tof/eqsans/elastic_correction.py
+++ b/src/drtsans/tof/eqsans/elastic_correction.py
@@ -183,6 +183,107 @@ def calculate_elastic_reference_normalization(wl_vec, x_vec, ref_i_1d):
     return k_vec, k_error_vec
 
 
+def save_wavelength_dependent_profiles(
+    i1d: IQmod | I1DAnnular,
+    k_vec: np.ndarray,
+    k_error_vec: np.ndarray,
+    output_dir: str,
+) -> None:
+    """Save I(1D) profiles before and after elastic K correction for each wavelength.
+
+    Parameters
+    ----------
+    i1d: IQmod | I1DAnnular
+        Input I(Q, wavelength) or I(phi, wavelength) to write profiles from
+    k_vec: ~numpy.ndarray
+        Elastic reference normalization factors (one for each wavelength)
+    k_error_vec: ~numpy.ndarray
+        Elastic reference normalization factor errors (one for each wavelength)
+    output_dir: str
+        Output directory for wavelength-dependent intensity profiles
+    """
+    wl_vec, x_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(i1d)
+    i1d_type = getDataType(i1d)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    for wl_index, wl in enumerate(wl_vec):
+        before_path = os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat")
+        before_i1d = build_i1d_one_wl_from_intensity_domain_meshgrid(
+            x_vec,
+            i_array,
+            error_array,
+            dq_array,
+            wl_index,
+            i1d_type,
+        )
+        save_i1d(before_i1d, before_path)
+
+    normalized_intensity, normalized_error = normalize_intensity_1d(
+        wl_vec,
+        x_vec,
+        i_array,
+        error_array,
+        k_vec,
+        k_error_vec,
+    )
+
+    for wl_index, wl in enumerate(wl_vec):
+        after_path = os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat")
+        after_i1d = build_i1d_one_wl_from_intensity_domain_meshgrid(
+            x_vec,
+            normalized_intensity,
+            normalized_error,
+            dq_array,
+            wl_index,
+            i1d_type,
+        )
+        save_i1d(after_i1d, after_path)
+
+
+def calculate_elastic_reference_k_factors(
+    i1d: IQmod | I1DAnnular,
+    ref_i1d: IQmod | I1DAnnular,
+    output_wavelength_dependent_profile: bool = False,
+    output_dir: Optional[str] = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Calculate elastic reference K factors without normalizing temporary products.
+
+    Parameters
+    ----------
+    i1d: IQmod | I1DAnnular
+        Input I(Q, wavelength) or I(phi, wavelength), used for bin validation and optional profiles
+    ref_i1d: IQmod | I1DAnnular
+        Elastic reference run I(Q, wavelength) or I(phi, wavelength)
+    output_wavelength_dependent_profile: bool
+        If True then output I for each wavelength before and after k correction
+    output_dir: str
+        Output directory for intensity profiles
+
+    Returns
+    -------
+    tuple
+        K vector and delta K vector
+    """
+    if not verify_same_q_bins(i1d, ref_i1d, False, tolerance=1e-3):
+        raise RuntimeError("Input I(1D) and elastic reference I(1D) have different binning")
+
+    wl_vec = np.unique(i1d.wavelength)
+    x_vec = np.unique(i1d.x)
+
+    k_vec, k_error_vec = calculate_elastic_reference_normalization(wl_vec, x_vec, ref_i1d)
+
+    if output_wavelength_dependent_profile and output_dir:
+        save_wavelength_dependent_profiles(
+            i1d,
+            k_vec,
+            k_error_vec,
+            output_dir,
+        )
+
+    return k_vec, k_error_vec
+
+
 def normalize_by_elastic_reference_1d(
     i1d: IQmod | I1DAnnular,
     k_vec: np.ndarray,
@@ -216,13 +317,12 @@ def normalize_by_elastic_reference_1d(
 
     i1d_type = getDataType(i1d)
     if output_wavelength_dependent_profile and output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-        for tmpwlii, wl in enumerate(wl_vec):
-            tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat")
-            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
-                x_vec, i_array, error_array, dq_array, tmpwlii, i1d_type
-            )
-            save_i1d(i1d_wl, tmpfn)
+        save_wavelength_dependent_profiles(
+            i1d,
+            k_vec,
+            k_error_vec,
+            output_dir,
+        )
 
     # Normalize
     normalized = normalize_intensity_1d(
@@ -238,14 +338,6 @@ def normalize_by_elastic_reference_1d(
     normalized_i1d = build_i1d_from_intensity_domain_meshgrid(
         wl_vec, x_vec, normalized[0], normalized[1], dq_array, i1d_type
     )
-
-    if output_wavelength_dependent_profile and output_dir:
-        for tmpwlii, wl in enumerate(wl_vec):
-            tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat")
-            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
-                x_vec, normalized[0], normalized[1], dq_array, tmpwlii, i1d_type
-            )
-            save_i1d(i1d_wl, tmpfn)
 
     return normalized_i1d
 
@@ -840,7 +932,7 @@ def elastic_correction(
 
     # Temporarily bin sample data to calculate k(λ) factors
     # These binned results are ONLY used for factor calculation, then discarded
-    iq2d_temp_binned, iq1d_temp_binned = bin_all(
+    _, iq1d_temp_binned = bin_all(
         iq2d_unbinned,
         iq1d_unbinned,
         num_x_bins,
@@ -862,7 +954,7 @@ def elastic_correction(
     )
 
     # Temporarily bin elastic reference data
-    iq2d_elastic_temp, iq1d_elastic_temp = bin_all(
+    _, iq1d_elastic_temp = bin_all(
         iq2d_elastic_ref,
         iq1d_elastic_ref,
         num_x_bins,
@@ -890,8 +982,7 @@ def elastic_correction(
     # Ensure output directory exists
     os.makedirs(output_dir, exist_ok=True)
 
-    _, _, k_vec, k_error_vec = normalize_by_elastic_reference_all(
-        iq2d_temp_binned,
+    k_vec, k_error_vec = calculate_elastic_reference_k_factors(
         iq1d_temp_binned[0],
         iq1d_elastic_temp[0],
         output_wavelength_profile,

--- a/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
+++ b/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
@@ -3,8 +3,10 @@ import pytest
 from drtsans.dataobjects import IQmod
 
 from drtsans.tof.eqsans.elastic_correction import (
+    calculate_elastic_reference_k_factors,
     determine_common_domain_range_mesh,
     normalize_by_elastic_reference_1d,
+    save_wavelength_dependent_profiles,
 )
 from drtsans.tof.eqsans.elastic_correction import (
     calculate_scale_factor_mesh_grid,
@@ -180,6 +182,77 @@ def test_workflow_q1d(temp_directory):
         assert os.path.exists(filename)
         data = np.loadtxt(filename)
         assert len(data) == expected_len[n]
+
+
+def test_save_wavelength_dependent_profiles_numeric_output(temp_directory):
+    """Test saving wavelength-dependent profiles before and after K correction."""
+    test_i_of_q, gold_k_vec, gold_k_error_vec, gold_intensity_vec, gold_error_vec = create_testing_iq1d()
+    output_dir = temp_directory()
+
+    save_wavelength_dependent_profiles(
+        test_i_of_q,
+        gold_k_vec,
+        gold_k_error_vec,
+        output_dir,
+    )
+
+    wl_vec, q_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(test_i_of_q)
+    gold_intensity_array = gold_intensity_vec.reshape(i_array.shape)
+    gold_error_array = gold_error_vec.reshape(error_array.shape)
+
+    for wl_index, wl in enumerate(wl_vec):
+        before_file = os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat")
+        before_data = np.loadtxt(before_file)
+        before_finite = np.isfinite(i_array[:, wl_index])
+
+        np.testing.assert_allclose(before_data[:, 0], q_vec[before_finite], rtol=1e-6)
+        np.testing.assert_allclose(before_data[:, 1], i_array[before_finite, wl_index], rtol=1e-6)
+        np.testing.assert_allclose(before_data[:, 2], error_array[before_finite, wl_index], rtol=1e-6)
+        np.testing.assert_allclose(before_data[:, 3], dq_array[before_finite, wl_index], rtol=1e-6)
+
+        after_file = os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat")
+        after_data = np.loadtxt(after_file)
+        after_finite = np.isfinite(gold_intensity_array[:, wl_index])
+
+        np.testing.assert_allclose(after_data[:, 0], q_vec[after_finite], rtol=1e-6)
+        np.testing.assert_allclose(after_data[:, 1], gold_intensity_array[after_finite, wl_index], rtol=8e-4)
+        np.testing.assert_allclose(after_data[:, 2], gold_error_array[after_finite, wl_index], rtol=1e-3)
+        np.testing.assert_allclose(after_data[:, 3], dq_array[after_finite, wl_index], rtol=1e-6)
+
+
+def test_calculate_elastic_reference_k_factors(temp_directory):
+    """Test K-only elastic reference helper."""
+    test_i_of_q, gold_k_vec, gold_k_error_vec, _, _ = create_testing_iq1d()
+    output_dir = temp_directory()
+
+    k_vec, k_error_vec = calculate_elastic_reference_k_factors(
+        test_i_of_q,
+        test_i_of_q,
+        output_wavelength_dependent_profile=True,
+        output_dir=output_dir,
+    )
+
+    np.testing.assert_allclose(k_vec, gold_k_vec, rtol=1e-5)
+    np.testing.assert_allclose(k_error_vec, gold_k_error_vec, rtol=1e-5)
+
+    for wl in np.unique(test_i_of_q.wavelength):
+        assert os.path.exists(os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat"))
+        assert os.path.exists(os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat"))
+
+
+def test_calculate_elastic_reference_k_factors_rejects_mismatched_bins():
+    """Test K-only helper rejects sample/reference 1D profiles with different bins."""
+    test_i_of_q, _, _, _, _ = create_testing_iq1d()
+    mismatched_i_of_q = IQmod(
+        intensity=test_i_of_q.intensity,
+        error=test_i_of_q.error,
+        mod_q=test_i_of_q.mod_q + 0.01,
+        delta_mod_q=test_i_of_q.delta_mod_q,
+        wavelength=test_i_of_q.wavelength,
+    )
+
+    with pytest.raises(RuntimeError, match="Input I\\(1D\\) and elastic reference I\\(1D\\) have different binning"):
+        calculate_elastic_reference_k_factors(test_i_of_q, mismatched_i_of_q)
 
 
 def test_normalize_i_of_q1d():


### PR DESCRIPTION
## Description of work:

**Check all that apply:**
- [ ] ~updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~Added integration tests~
- [ ] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [16511](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16511)

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
