### PR TITLE
Refactor elastic correction workflow

### DIFF
--- a/src/drtsans/tof/eqsans/elastic_correction.py
+++ b/src/drtsans/tof/eqsans/elastic_correction.py
@@ -183,6 +183,107 @@ def calculate_elastic_reference_normalization(wl_vec, x_vec, ref_i_1d):
     return k_vec, k_error_vec
 
 
+def save_wavelength_dependent_profiles(
+    i1d: IQmod | I1DAnnular,
+    k_vec: np.ndarray,
+    k_error_vec: np.ndarray,
+    output_dir: str,
+) -> None:
+    """Save I(1D) profiles before and after elastic K correction for each wavelength.
+
+    Parameters
+    ----------
+    i1d: IQmod | I1DAnnular
+        Input I(Q, wavelength) or I(phi, wavelength) to write profiles from
+    k_vec: ~numpy.ndarray
+        Elastic reference normalization factors (one for each wavelength)
+    k_error_vec: ~numpy.ndarray
+        Elastic reference normalization factor errors (one for each wavelength)
+    output_dir: str
+        Output directory for wavelength-dependent intensity profiles
+    """
+    wl_vec, x_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(i1d)
+    i1d_type = getDataType(i1d)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    for wl_index, wl in enumerate(wl_vec):
+        before_path = os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat")
+        before_i1d = build_i1d_one_wl_from_intensity_domain_meshgrid(
+            x_vec,
+            i_array,
+            error_array,
+            dq_array,
+            wl_index,
+            i1d_type,
+        )
+        save_i1d(before_i1d, before_path)
+
+    normalized_intensity, normalized_error = normalize_intensity_1d(
+        wl_vec,
+        x_vec,
+        i_array,
+        error_array,
+        k_vec,
+        k_error_vec,
+    )
+
+    for wl_index, wl in enumerate(wl_vec):
+        after_path = os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat")
+        after_i1d = build_i1d_one_wl_from_intensity_domain_meshgrid(
+            x_vec,
+            normalized_intensity,
+            normalized_error,
+            dq_array,
+            wl_index,
+            i1d_type,
+        )
+        save_i1d(after_i1d, after_path)
+
+
+def calculate_elastic_reference_k_factors(
+    i1d: IQmod | I1DAnnular,
+    ref_i1d: IQmod | I1DAnnular,
+    output_wavelength_dependent_profile: bool = False,
+    output_dir: Optional[str] = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Calculate elastic reference K factors without normalizing temporary products.
+
+    Parameters
+    ----------
+    i1d: IQmod | I1DAnnular
+        Input I(Q, wavelength) or I(phi, wavelength), used for bin validation and optional profiles
+    ref_i1d: IQmod | I1DAnnular
+        Elastic reference run I(Q, wavelength) or I(phi, wavelength)
+    output_wavelength_dependent_profile: bool
+        If True then output I for each wavelength before and after k correction
+    output_dir: str
+        Output directory for intensity profiles
+
+    Returns
+    -------
+    tuple
+        K vector and delta K vector
+    """
+    if not verify_same_q_bins(i1d, ref_i1d, False, tolerance=1e-3):
+        raise RuntimeError("Input I(1D) and elastic reference I(1D) have different binning")
+
+    wl_vec = np.unique(i1d.wavelength)
+    x_vec = np.unique(i1d.x)
+
+    k_vec, k_error_vec = calculate_elastic_reference_normalization(wl_vec, x_vec, ref_i1d)
+
+    if output_wavelength_dependent_profile and output_dir:
+        save_wavelength_dependent_profiles(
+            i1d,
+            k_vec,
+            k_error_vec,
+            output_dir,
+        )
+
+    return k_vec, k_error_vec
+
+
 def normalize_by_elastic_reference_1d(
     i1d: IQmod | I1DAnnular,
     k_vec: np.ndarray,
@@ -216,13 +317,12 @@ def normalize_by_elastic_reference_1d(
 
     i1d_type = getDataType(i1d)
     if output_wavelength_dependent_profile and output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-        for tmpwlii, wl in enumerate(wl_vec):
-            tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat")
-            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
-                x_vec, i_array, error_array, dq_array, tmpwlii, i1d_type
-            )
-            save_i1d(i1d_wl, tmpfn)
+        save_wavelength_dependent_profiles(
+            i1d,
+            k_vec,
+            k_error_vec,
+            output_dir,
+        )
 
     # Normalize
     normalized = normalize_intensity_1d(
@@ -238,14 +338,6 @@ def normalize_by_elastic_reference_1d(
     normalized_i1d = build_i1d_from_intensity_domain_meshgrid(
         wl_vec, x_vec, normalized[0], normalized[1], dq_array, i1d_type
     )
-
-    if output_wavelength_dependent_profile and output_dir:
-        for tmpwlii, wl in enumerate(wl_vec):
-            tmpfn = os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat")
-            i1d_wl = build_i1d_one_wl_from_intensity_domain_meshgrid(
-                x_vec, normalized[0], normalized[1], dq_array, tmpwlii, i1d_type
-            )
-            save_i1d(i1d_wl, tmpfn)
 
     return normalized_i1d
 
@@ -840,7 +932,7 @@ def elastic_correction(
 
     # Temporarily bin sample data to calculate k(λ) factors
     # These binned results are ONLY used for factor calculation, then discarded
-    iq2d_temp_binned, iq1d_temp_binned = bin_all(
+    _, iq1d_temp_binned = bin_all(
         iq2d_unbinned,
         iq1d_unbinned,
         num_x_bins,
@@ -862,7 +954,7 @@ def elastic_correction(
     )
 
     # Temporarily bin elastic reference data
-    iq2d_elastic_temp, iq1d_elastic_temp = bin_all(
+    _, iq1d_elastic_temp = bin_all(
         iq2d_elastic_ref,
         iq1d_elastic_ref,
         num_x_bins,
@@ -890,8 +982,7 @@ def elastic_correction(
     # Ensure output directory exists
     os.makedirs(output_dir, exist_ok=True)
 
-    _, _, k_vec, k_error_vec = normalize_by_elastic_reference_all(
-        iq2d_temp_binned,
+    k_vec, k_error_vec = calculate_elastic_reference_k_factors(
         iq1d_temp_binned[0],
         iq1d_elastic_temp[0],
         output_wavelength_profile,

--- a/src/drtsans/tof/eqsans/elastic_correction.py
+++ b/src/drtsans/tof/eqsans/elastic_correction.py
@@ -358,12 +358,23 @@ def normalize_by_elastic_reference_2d(i_of_q, k_vec, k_error_vec):
     -------
     ~drtsans.dataobjects.IQazimuthal
         normalized I(Q2D)
+
+    Raises
+    ------
+    ValueError
+        If ``k_vec`` or ``k_error_vec`` is not a 1D vector with one entry per wavelength
+        bin of ``i_of_q``
     """
     intensity_array = i_of_q.intensity
     error_array = i_of_q.error
 
     # Reshape vectors to be easily indexed by wavelength
     num_wl = len(np.unique(i_of_q.wavelength))
+
+    # The loops below are bounded by this data's wavelength count, not by the length of the
+    # supplied factors, so a longer k_vec would have its trailing entries silently left unread.
+    _validate_k_vectors(num_wl, k_vec, k_error_vec)
+
     sizeX = i_of_q.qx.shape[0]
     sizeY = i_of_q.qy.shape[0]
     intensity_3d = intensity_array.transpose().reshape((num_wl, sizeX, sizeY))
@@ -668,6 +679,37 @@ def determine_reference_wavelength_intensity_mesh(
     return ReferenceWavelengths(x_vec, min_wl_vec, min_intensity_vec, min_error_vec)
 
 
+def _validate_k_vectors(num_wavelengths: int, k_vec, k_error_vec) -> None:
+    """Reject K factor vectors that are not one entry per wavelength.
+
+    Both the 1D and 2D normalizations take caller-supplied K factors indexed by wavelength
+    alone. In the 1D path a 2D array silently broadcasts along the Q axis, scaling each Q bin
+    instead of each wavelength; in the 2D path a vector longer than the wavelength grid has its
+    trailing factors silently left unread. Validate the contract before either is used.
+
+    Parameters
+    ----------
+    num_wavelengths: int
+        Number of wavelength bins the factors must cover
+    k_vec: ~numpy.ndarray
+        Elastic reference normalization factors
+    k_error_vec: ~numpy.ndarray
+        Elastic reference normalization factor errors
+
+    Raises
+    ------
+    ValueError
+        If either vector is not a 1D vector with exactly ``num_wavelengths`` entries
+    """
+    for name, vec in (("k_vec", k_vec), ("k_error_vec", k_error_vec)):
+        if np.ndim(vec) != 1:
+            raise ValueError(f"{name} must be a 1D vector, got {np.ndim(vec)} dimension(s)")
+        if np.size(vec) != num_wavelengths:
+            raise ValueError(
+                f"{name} must have one entry per wavelength: expected {num_wavelengths}, got {np.size(vec)}"
+            )
+
+
 def normalize_intensity_1d(
     wl_vec,
     x_vec,
@@ -698,12 +740,19 @@ def normalize_intensity_1d(
     tuple
         normalized I(1D), normalized error(1D)
 
+    Raises
+    ------
+    ValueError
+        If ``k_vec`` or ``k_error_vec`` is not a 1D vector with one entry per wavelength
+
     """
 
     # Sanity check
     assert wl_vec.shape[0] == intensity_array.shape[1]  # wavelength as lambda
     assert x_vec.shape[0] == error_array.shape[0]  # points as Q or phi
     assert intensity_array.shape == error_array.shape
+
+    _validate_k_vectors(wl_vec.shape[0], k_vec, k_error_vec)
 
     # Normalized intensities
     normalized_intensity_array = intensity_array * k_vec

--- a/src/drtsans/tof/eqsans/elastic_correction.py
+++ b/src/drtsans/tof/eqsans/elastic_correction.py
@@ -257,7 +257,7 @@ def calculate_elastic_reference_k_factors(
         Elastic reference run I(Q, wavelength) or I(phi, wavelength)
     output_wavelength_dependent_profile: bool
         If True then output I for each wavelength before and after k correction
-    output_dir: str
+    output_dir: str, optional
         Output directory for intensity profiles
 
     Returns
@@ -802,6 +802,12 @@ def apply_elastic_normalization_to_unbinned_data(
     -------
     tuple[IQazimuthal, IQmod]
         Normalized unbinned I(Qx, Qy, λ) and I(Q, λ)
+
+    Raises
+    ------
+    ValueError
+        If ``k_vec`` or ``k_error_vec`` is not a 1D vector with one entry per ``wl_vec``
+        wavelength
     """
 
     # Helper function to create numpy-based interpolation with edge handling
@@ -831,6 +837,10 @@ def apply_elastic_normalization_to_unbinned_data(
             return np.interp(new_x, x, y, left=left, right=right)
 
         return _interp
+
+    # np.interp below already rejects a mismatched or multi-dimensional factor vector, but with
+    # a message about its own internals. Fail with the same contract as the binned normalizations.
+    _validate_k_vectors(np.size(wl_vec), k_vec, k_error_vec)
 
     # Create interpolation functions for k and k_error
     k_interp = _make_interp_fn(wl_vec, k_vec)

--- a/src/drtsans/tof/eqsans/elastic_correction.py
+++ b/src/drtsans/tof/eqsans/elastic_correction.py
@@ -112,8 +112,8 @@ def normalize_by_elastic_reference_all(
         Input I(Q1D, wavelength) or I(phi, wavelength) as elastic reference run
     output_wavelength_dependent_profile: bool
         If True then output I(1D) for each wavelength before and after k correction
-    output_dir: str
-        output directory for I(1D) profiles
+    output_dir: str, optional
+        Output directory for I(1D) profiles. If None, no profile files are written.
 
     Returns
     -------
@@ -258,7 +258,7 @@ def calculate_elastic_reference_k_factors(
     output_wavelength_dependent_profile: bool
         If True then output I for each wavelength before and after k correction
     output_dir: str, optional
-        Output directory for intensity profiles
+        Output directory for intensity profiles. If None, no profile files are written.
 
     Returns
     -------
@@ -303,8 +303,8 @@ def normalize_by_elastic_reference_1d(
         Elastic reference normalization factor errors (one for each wavelength)
     output_wavelength_dependent_profile: bool
         If True then output I for each wavelength before and after k correction
-    output_dir: str
-        output directory for intensity profiles
+    output_dir: str, optional
+        Output directory for intensity profiles. If None, no profile files are written.
 
     Returns
     -------

--- a/tests/integration/drtsans/tof/eqsans/test_elastic_and_inelastic_corrections.py
+++ b/tests/integration/drtsans/tof/eqsans/test_elastic_and_inelastic_corrections.py
@@ -180,14 +180,7 @@ def test_parse_invalid_json(datarepo_dir):
     [
         (False, False),
         (True, False),
-        pytest.param(
-            False,
-            True,
-            marks=pytest.mark.skip(
-                reason="EWM-13940: Gold files need regeneration after one-rebin-only implementation. "
-                "Elastic correction now applied to unbinned data, producing different (correct) results."
-            ),
-        ),
+        (False, True),
         pytest.param(
             True,
             True,
@@ -330,6 +323,7 @@ def test_incoherence_correction_elastic_normalization(
         np.testing.assert_allclose(
             np.loadtxt(test_k_file, delimiter=",", skiprows=1),
             np.loadtxt(os.path.join(reference_data_dir, k_base_name), delimiter=",", skiprows=1),
+            rtol=1e-6,  # gold generated on one machine; absorbs least-significant-digit platform differences
         )
 
     # check the b factor file, if inelastic correction is enabled

--- a/tests/integration/drtsans/tof/eqsans/test_elastic_and_inelastic_corrections.py
+++ b/tests/integration/drtsans/tof/eqsans/test_elastic_and_inelastic_corrections.py
@@ -179,14 +179,7 @@ def test_parse_invalid_json(datarepo_dir):
     "fitInelasticIncoh, elastic_reference_run",
     [
         (False, False),
-        pytest.param(
-            True,
-            False,
-            marks=pytest.mark.skip(
-                reason="EWM-13940: Gold files need regeneration after SNS cluster validation. "
-                "This test compares new correct output against old buggy gold files."
-            ),
-        ),
+        (True, False),
         pytest.param(
             False,
             True,
@@ -347,6 +340,7 @@ def test_incoherence_correction_elastic_normalization(
         np.testing.assert_allclose(
             np.loadtxt(test_b_file, delimiter=",", skiprows=1),
             np.loadtxt(os.path.join(reference_data_dir, b_base_name), delimiter=",", skiprows=1),
+            rtol=1e-6,  # gold generated on one machine; absorbs least-significant-digit platform differences
         )
 
     # cleanup

--- a/tests/integration/drtsans/tof/eqsans/test_elastic_and_inelastic_corrections.py
+++ b/tests/integration/drtsans/tof/eqsans/test_elastic_and_inelastic_corrections.py
@@ -181,14 +181,7 @@ def test_parse_invalid_json(datarepo_dir):
         (False, False),
         (True, False),
         (False, True),
-        pytest.param(
-            True,
-            True,
-            marks=pytest.mark.skip(
-                reason="EWM-13940: Gold files need regeneration after SNS cluster validation. "
-                "This test compares new correct output against old buggy gold files."
-            ),
-        ),
+        (True, True),
     ],
 )
 def test_incoherence_correction_elastic_normalization(

--- a/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
+++ b/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
@@ -291,6 +291,31 @@ def test_normalize_i_of_q1d():
     np.testing.assert_allclose(normalized_error, gold_error_vec, rtol=1e-3, equal_nan=True)
 
 
+def test_normalize_i_of_q1d_rejects_two_dimensional_k_vector():
+    """A column-shaped K vector broadcasts along the Q axis instead of the wavelength axis,
+    silently scaling each Q bin, so it must be rejected"""
+    test_i_of_q = create_testing_iq1d()[0]
+    wl_vec, q_vec, i_array, error_array, _ = reshape_intensity_domain_meshgrid(test_i_of_q)
+
+    column_shaped_k_vec = np.ones((wl_vec.shape[0], 1))
+    k_error_vec = np.zeros(wl_vec.shape[0])
+
+    with pytest.raises(ValueError, match="k_vec must be a 1D vector"):
+        normalize_intensity_1d(wl_vec, q_vec, i_array, error_array, column_shaped_k_vec, k_error_vec)
+
+
+def test_normalize_i_of_q1d_rejects_k_vector_of_wrong_length():
+    """Exactly one K factor and one K error is required per wavelength"""
+    test_i_of_q = create_testing_iq1d()[0]
+    wl_vec, q_vec, i_array, error_array, _ = reshape_intensity_domain_meshgrid(test_i_of_q)
+
+    k_vec = np.ones(wl_vec.shape[0])
+    truncated_k_error_vec = np.zeros(wl_vec.shape[0] - 1)
+
+    with pytest.raises(ValueError, match="k_error_vec must have one entry per wavelength"):
+        normalize_intensity_1d(wl_vec, q_vec, i_array, error_array, k_vec, truncated_k_error_vec)
+
+
 def create_testing_iq1d():
     """Create a test data I(Q, wavelength) as the attached EXCEL spreadsheet attached in gitlab story
     Returns

--- a/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
+++ b/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
@@ -3,8 +3,10 @@ import pytest
 from drtsans.dataobjects import IQmod
 
 from drtsans.tof.eqsans.elastic_correction import (
+    calculate_elastic_reference_k_factors,
     determine_common_domain_range_mesh,
     normalize_by_elastic_reference_1d,
+    save_wavelength_dependent_profiles,
 )
 from drtsans.tof.eqsans.elastic_correction import (
     calculate_scale_factor_mesh_grid,
@@ -180,6 +182,77 @@ def test_workflow_q1d(temp_directory):
         assert os.path.exists(filename)
         data = np.loadtxt(filename)
         assert len(data) == expected_len[n]
+
+
+def test_save_wavelength_dependent_profiles_numeric_output(temp_directory):
+    """Test saving wavelength-dependent profiles before and after K correction."""
+    test_i_of_q, gold_k_vec, gold_k_error_vec, gold_intensity_vec, gold_error_vec = create_testing_iq1d()
+    output_dir = temp_directory()
+
+    save_wavelength_dependent_profiles(
+        test_i_of_q,
+        gold_k_vec,
+        gold_k_error_vec,
+        output_dir,
+    )
+
+    wl_vec, q_vec, i_array, error_array, dq_array = reshape_intensity_domain_meshgrid(test_i_of_q)
+    gold_intensity_array = gold_intensity_vec.reshape(i_array.shape)
+    gold_error_array = gold_error_vec.reshape(error_array.shape)
+
+    for wl_index, wl in enumerate(wl_vec):
+        before_file = os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat")
+        before_data = np.loadtxt(before_file)
+        before_finite = np.isfinite(i_array[:, wl_index])
+
+        np.testing.assert_allclose(before_data[:, 0], q_vec[before_finite], rtol=1e-6)
+        np.testing.assert_allclose(before_data[:, 1], i_array[before_finite, wl_index], rtol=1e-6)
+        np.testing.assert_allclose(before_data[:, 2], error_array[before_finite, wl_index], rtol=1e-6)
+        np.testing.assert_allclose(before_data[:, 3], dq_array[before_finite, wl_index], rtol=1e-6)
+
+        after_file = os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat")
+        after_data = np.loadtxt(after_file)
+        after_finite = np.isfinite(gold_intensity_array[:, wl_index])
+
+        np.testing.assert_allclose(after_data[:, 0], q_vec[after_finite], rtol=1e-6)
+        np.testing.assert_allclose(after_data[:, 1], gold_intensity_array[after_finite, wl_index], rtol=8e-4)
+        np.testing.assert_allclose(after_data[:, 2], gold_error_array[after_finite, wl_index], rtol=1e-3)
+        np.testing.assert_allclose(after_data[:, 3], dq_array[after_finite, wl_index], rtol=1e-6)
+
+
+def test_calculate_elastic_reference_k_factors(temp_directory):
+    """Test K-only elastic reference helper."""
+    test_i_of_q, gold_k_vec, gold_k_error_vec, _, _ = create_testing_iq1d()
+    output_dir = temp_directory()
+
+    k_vec, k_error_vec = calculate_elastic_reference_k_factors(
+        test_i_of_q,
+        test_i_of_q,
+        output_wavelength_dependent_profile=True,
+        output_dir=output_dir,
+    )
+
+    np.testing.assert_allclose(k_vec, gold_k_vec, rtol=1e-5)
+    np.testing.assert_allclose(k_error_vec, gold_k_error_vec, rtol=1e-5)
+
+    for wl in np.unique(test_i_of_q.wavelength):
+        assert os.path.exists(os.path.join(output_dir, f"IQ_{wl:.3f}_before_k_correction.dat"))
+        assert os.path.exists(os.path.join(output_dir, f"IQ_{wl:.3f}_after_k_correction.dat"))
+
+
+def test_calculate_elastic_reference_k_factors_rejects_mismatched_bins():
+    """Test K-only helper rejects sample/reference 1D profiles with different bins."""
+    test_i_of_q, _, _, _, _ = create_testing_iq1d()
+    mismatched_i_of_q = IQmod(
+        intensity=test_i_of_q.intensity,
+        error=test_i_of_q.error,
+        mod_q=test_i_of_q.mod_q + 0.01,
+        delta_mod_q=test_i_of_q.delta_mod_q,
+        wavelength=test_i_of_q.wavelength,
+    )
+
+    with pytest.raises(RuntimeError, match="Input I\\(1D\\) and elastic reference I\\(1D\\) have different binning"):
+        calculate_elastic_reference_k_factors(test_i_of_q, mismatched_i_of_q)
 
 
 def test_normalize_i_of_q1d():

--- a/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
+++ b/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization.py
@@ -3,6 +3,7 @@ import pytest
 from drtsans.dataobjects import IQmod
 
 from drtsans.tof.eqsans.elastic_correction import (
+    apply_elastic_normalization_to_unbinned_data,
     calculate_elastic_reference_k_factors,
     determine_common_domain_range_mesh,
     normalize_by_elastic_reference_1d,
@@ -314,6 +315,24 @@ def test_normalize_i_of_q1d_rejects_k_vector_of_wrong_length():
 
     with pytest.raises(ValueError, match="k_error_vec must have one entry per wavelength"):
         normalize_intensity_1d(wl_vec, q_vec, i_array, error_array, k_vec, truncated_k_error_vec)
+
+
+def test_apply_elastic_normalization_rejects_k_vector_of_wrong_length():
+    """One K factor per wavelength is required before the factors are interpolated onto the
+    unbinned wavelengths. The K vectors are validated ahead of the data, so no unbinned
+    workspaces are needed to exercise the contract"""
+    wl_vec = np.array([3.0, 4.0, 5.0])
+
+    with pytest.raises(ValueError, match="k_vec must have one entry per wavelength"):
+        apply_elastic_normalization_to_unbinned_data(None, None, wl_vec, np.ones(4), np.zeros(3))
+
+
+def test_apply_elastic_normalization_rejects_two_dimensional_k_vector():
+    """K factors are indexed by wavelength alone, so a 2D array is not a valid input"""
+    wl_vec = np.array([3.0, 4.0, 5.0])
+
+    with pytest.raises(ValueError, match="k_vec must be a 1D vector"):
+        apply_elastic_normalization_to_unbinned_data(None, None, wl_vec, np.ones((3, 1)), np.zeros(3))
 
 
 def create_testing_iq1d():

--- a/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization_2d.py
+++ b/tests/unit/drtsans/tof/eqsans/test_elastic_reference_normalization_2d.py
@@ -103,5 +103,27 @@ def test_normalize_by_elastic_reference2d():
     np.testing.assert_allclose(normalized_i_of_q.error, expected_normalized_i_of_q.error, rtol=1e-5)
 
 
+def test_normalize_by_elastic_reference2d_rejects_overlong_k_vector():
+    """A K vector longer than the wavelength grid would have its trailing factors silently
+    left unread, applying the remaining factors to the wrong wavelengths"""
+    i_of_q, _, k_vec, k_error_vec = create_testing_iq2d()
+
+    overlong_k_vec = list(k_vec) + [1.1]
+
+    with pytest.raises(ValueError, match="k_vec must have one entry per wavelength"):
+        normalize_by_elastic_reference_2d(i_of_q, overlong_k_vec, k_error_vec)
+
+
+def test_normalize_by_elastic_reference2d_rejects_two_dimensional_k_vector():
+    """K factors are indexed by wavelength alone, so a 2D array is not a valid input even
+    where it happens to broadcast correctly"""
+    i_of_q, _, k_vec, k_error_vec = create_testing_iq2d()
+
+    column_shaped_k_vec = np.array(k_vec).reshape(len(k_vec), 1)
+
+    with pytest.raises(ValueError, match="k_vec must be a 1D vector"):
+        normalize_by_elastic_reference_2d(i_of_q, column_shaped_k_vec, k_error_vec)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Description of work:
Refactor the EQSANS elastic reference correction workflow by extracting reusable helpers for computing wavelength-dependent K factors and for writing pre/post-correction wavelength profiles, and by tightening input validation around K-factor vector shapes.
Update the main `elastic_correction()` workflow to compute K(λ) factors via the new helper and adds unit tests covering the new behaviors and validation.

**Changes:**
- Added `calculate_elastic_reference_k_factors()` (K-only helper) and `save_wavelength_dependent_profiles()` (debug/profile output helper).
- Added strict validation to reject invalid `k_vec` / `k_error_vec` shapes and lengths for both 1D and 2D normalization paths.
- Added/expanded unit tests to cover profile output and K-vector validation edge cases.

**Check all that apply:**
- [ ] ~updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~Added integration tests~
- [ ] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [16511](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16511)

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```

