### PR TITLE
Use MCON16 sample log to detect EQSANS monochromatic mode

### DIFF
--- a/docs/user/eqsans_reduction.rst
+++ b/docs/user/eqsans_reduction.rst
@@ -11,12 +11,14 @@ Monochromatic Mode
 EQSANS can be operated in monochromatic mode, for runs
 where the chopper system is phased to transmit a typically narrow wavelength band,
 instead of the broad time-of-flight spectrum used in normal operation.
-This mode is recorded in the raw data file through the ``"monochromatic"`` sample log,
+This mode is recorded in the raw data file through the process variable ``BL6:Chop:Skf16:MCON``,
 set by the instrument's data acquisition system — it is not a setting in the reduction configuration.
+This process variable has the associated alias ``MCON16``, which is the name under which it appears
+in the sample logs of the raw data file, and thus the name `drtsans` looks up.
 The behavior described below is triggered by the *value* of this boolean sample log; the mere
 presence of the log in the file is not enough to trigger monochromatic mode.
 
-When the ``"monochromatic"`` sample log evaluates to ``True``, `drtsans` overrides the wavelength bin width
+When the ``MCON16`` sample log evaluates to ``True``, `drtsans` overrides the wavelength bin width
 passed in the configuration file so that the entire transmitted band is treated as one bin spanning
 the full range of wavelengths present in the data. Monochromatic mode is incompatible with
 frame-skipping mode.

--- a/src/drtsans/tof/eqsans/correct_frame.py
+++ b/src/drtsans/tof/eqsans/correct_frame.py
@@ -35,6 +35,10 @@ __all__ = ["transform_to_wavelength"]
 # maximum difference between wavelength bands of runs to be summed
 WAVELENGTH_BAND_DIFF_TOLERANCE = 0.1  # Angstrom
 
+# Alias of DAS process variable "BL6:Chop:Skf16:MCON", recording whether the run was taken in
+# monochromatic mode. The alias is the name under which the variable appears in the sample logs.
+MONOCHROMATIC_PV = "MCON16"
+
 # Default TOF clipping values from EQSANS.json schema (in microseconds)
 _eqsans_defaults = default_reduction_parameters("EQSANS")["configuration"]
 DEFAULT_LOW_TOF_CLIP = _eqsans_defaults["cutTOFmin"]  # 500.0 µs
@@ -621,7 +625,7 @@ def convert_to_wavelength(input_workspace, bands=None, bin_width=0.1, events=Tru
         band structure will be read from the logs.
     bin_width: float
         Bin width in Angstroms. Ignored if the workspace is in monochromatic mode (sample log
-        ``monochromatic`` is ``True``), in which case a single bin spanning the transmitted band
+        ``MCON16`` is ``True``), in which case a single bin spanning the transmitted band
         is used instead.
     events: bool
         Do we preserve events?
@@ -655,8 +659,8 @@ def convert_to_wavelength(input_workspace, bands=None, bin_width=0.1, events=Tru
 
     # If in monochromatic mode, override `bin_width`
     sample_logs = SampleLogs(input_workspace)
-    if "monochromatic" in sample_logs.keys():
-        is_monochromatic = bool(sample_logs.single_value("monochromatic"))
+    if MONOCHROMATIC_PV in sample_logs.keys():
+        is_monochromatic = bool(sample_logs.single_value(MONOCHROMATIC_PV))
     else:
         is_monochromatic = False
     if is_monochromatic:

--- a/tests/unit/drtsans/tof/eqsans/test_convert_tof_to_wavelength.py
+++ b/tests/unit/drtsans/tof/eqsans/test_convert_tof_to_wavelength.py
@@ -12,6 +12,8 @@ from drtsans.tof.eqsans.correct_frame import (
     convert_to_wavelength,
     transform_to_wavelength,
     IncompatibleWavelengthBandsError,
+    MONOCHROMATIC_PV,
+    TransmittedBands,
     WAVELENGTH_BAND_DIFF_TOLERANCE,
 )
 from drtsans.wavelength import Wband, from_tof
@@ -20,6 +22,11 @@ from drtsans.wavelength import Wband, from_tof
 def add_frame_skipping_log(ws):
     samplelog = SampleLogs(ws)
     samplelog.insert("is_frame_skipping", False)
+
+
+def add_monochromatic_log(ws, value=1):
+    """Emulate the data acquisition system flagging the run as taken in monochromatic mode"""
+    SampleLogs(ws).insert(MONOCHROMATIC_PV, value)
 
 
 @pytest.mark.parametrize(
@@ -118,6 +125,77 @@ def test_shuo(generic_workspace, clean_workspace):
 
         # Verify wavelength values are in reasonable range (monotonically increasing)
         assert ws.dataX(i)[0] < ws.dataX(i)[1]
+
+
+# Workspace spanning, after conversion to wavelength, a range wider than `MONOCHROMATIC_BAND`
+MONOCHROMATIC_WORKSPACE = {
+    "dx": 0.005,
+    "dy": 0.004,
+    "zc": 5.0,
+    "l1": 14.0,
+    "axis_units": "tof",
+    "axis_values": [10000.0, 20000.0],
+}
+
+# Wavelength band transmitted by the choppers, in Angstroms
+MONOCHROMATIC_BAND = Wband(2.5, 3.5)
+
+
+@pytest.mark.parametrize("generic_workspace", [MONOCHROMATIC_WORKSPACE], indirect=True)
+def test_convert_to_wavelength_monochromatic(generic_workspace, clean_workspace):
+    """In monochromatic mode the requested bin width is overridden by a single bin spanning
+    the whole transmitted band"""
+    ws = generic_workspace
+    clean_workspace(ws)
+    add_frame_skipping_log(ws)
+    add_monochromatic_log(ws)
+
+    bands = TransmittedBands(lead=MONOCHROMATIC_BAND, skip=None)
+    ws = convert_to_wavelength(ws, bands=bands, bin_width=0.1)
+
+    assert ws.dataX(0) == pytest.approx([MONOCHROMATIC_BAND.min, MONOCHROMATIC_BAND.max])
+    band_width = MONOCHROMATIC_BAND.max - MONOCHROMATIC_BAND.min  # Angstrom
+    assert SampleLogs(ws).single_value("wavelength_bin_width") == pytest.approx(band_width)
+
+
+@pytest.mark.parametrize("generic_workspace", [MONOCHROMATIC_WORKSPACE], indirect=True)
+def test_convert_to_wavelength_not_monochromatic(generic_workspace, clean_workspace):
+    """Without the MCON16 sample log, the requested bin width is honored"""
+    ws = generic_workspace
+    clean_workspace(ws)
+    add_frame_skipping_log(ws)
+
+    bands = TransmittedBands(lead=MONOCHROMATIC_BAND, skip=None)
+    ws = convert_to_wavelength(ws, bands=bands, bin_width=0.1)
+
+    wavelength_bin_edges = ws.dataX(0)
+    assert len(wavelength_bin_edges) > 2  # more than a single bin
+    assert wavelength_bin_edges[1] - wavelength_bin_edges[0] == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize("generic_workspace", [MONOCHROMATIC_WORKSPACE], indirect=True)
+def test_convert_to_wavelength_monochromatic_frame_skipping(generic_workspace, clean_workspace):
+    """Monochromatic mode and frame-skipping mode are mutually exclusive chopper settings"""
+    ws = generic_workspace
+    clean_workspace(ws)
+    SampleLogs(ws).insert("is_frame_skipping", True)
+    add_monochromatic_log(ws)
+
+    bands = TransmittedBands(lead=Wband(2.5, 3.0), skip=Wband(3.2, 3.5))
+    with pytest.raises(ValueError, match="incompatible with frame-skipping"):
+        convert_to_wavelength(ws, bands=bands)
+
+
+@pytest.mark.parametrize("generic_workspace", [MONOCHROMATIC_WORKSPACE], indirect=True)
+def test_convert_to_wavelength_monochromatic_unknown_bands(generic_workspace, clean_workspace):
+    """The single bin cannot be constructed if the transmitted band is neither passed nor logged"""
+    ws = generic_workspace
+    clean_workspace(ws)
+    add_frame_skipping_log(ws)
+    add_monochromatic_log(ws)
+
+    with pytest.raises(ValueError, match="requires the wavelength bands"):
+        convert_to_wavelength(ws)
 
 
 @pytest.mark.datarepo

--- a/tests/unit/drtsans/tof/eqsans/test_convert_tof_to_wavelength.py
+++ b/tests/unit/drtsans/tof/eqsans/test_convert_tof_to_wavelength.py
@@ -160,10 +160,11 @@ def test_convert_to_wavelength_monochromatic(generic_workspace, clean_workspace)
 
 @pytest.mark.parametrize("generic_workspace", [MONOCHROMATIC_WORKSPACE], indirect=True)
 def test_convert_to_wavelength_not_monochromatic(generic_workspace, clean_workspace):
-    """Without the MCON16 sample log, the requested bin width is honored"""
+    """Without a true MCON16 sample log, the requested bin width is honored"""
     ws = generic_workspace
     clean_workspace(ws)
     add_frame_skipping_log(ws)
+    add_monochromatic_log(ws, value=0)
 
     bands = TransmittedBands(lead=MONOCHROMATIC_BAND, skip=None)
     ws = convert_to_wavelength(ws, bands=bands, bin_width=0.1)


### PR DESCRIPTION
## Description of work:

The monochromatic-mode flag is recorded by the DAS process variable "BL6:Chop:Skf16:MCON", which appears in the sample logs under its alias "MCON16". The reduction was reading a placeholder log named "monochromatic", so real monochromatic runs were reduced as broadband data with the configured wavelength bin width.

- introduce constant MONOCHROMATIC_PV = "MCON16" in correct_frame.py
- update the EQSANS user documentation to name the process variable
- add unit tests for the monochromatic branch of convert_to_wavelength
- bump the data repository, where the synthetic sample log of run 177103 has been renamed to MCON16

**Check all that apply:**
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~Added integration tests~
- [ ] Included a manual test for the reviewer
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [17367](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=17367)

## :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
