### PR TITLE
Fall back to local IDF when the download returns a non-200 status

### DIFF
--- a/scripts/autoreduction/reduce_EQSANS.py
+++ b/scripts/autoreduction/reduce_EQSANS.py
@@ -638,6 +638,8 @@ def autoreduce(args: argparse.Namespace):
     logger = logging.getLogger(LOG_NAME)
     logger.info(f"Loading events from {args.events_file}")
     events = LoadEventNexus(Filename=args.events_file, OutputWorkspace=mtd.unique_hidden_name())
+    if events.getNumberEvents() == 0:
+        raise RuntimeError(f"File {args.events_file} has no events after loading with LoadEventNexus")
 
     # amend the output directory, if necessary
     ipts = SampleLogs(events).experiment_identifier.value[5:]  # e.g. "12345" when having IPTS-12345

--- a/src/drtsans/instruments.py
+++ b/src/drtsans/instruments.py
@@ -1,5 +1,5 @@
 # third party imports
-from mantid.kernel import ConfigService
+from mantid.kernel import ConfigService, Logger
 from mantid.api import mtd, MatrixWorkspace
 from mantid.dataobjects import EventWorkspace
 from mantid.simpleapi import (
@@ -10,12 +10,12 @@ from mantid.simpleapi import (
     RemoveSpectra,
     RenameWorkspace,
 )
+import requests
 
 # standard imports
 import enum
 import os
 import shutil
-import subprocess
 from typing import Optional, Union
 
 
@@ -27,6 +27,8 @@ __all__ = [
 ]
 
 INSTRUMENT_LABELS = ["CG3", "BIOSANS", "EQ-SANS", "EQSANS", "CG2", "GPSANS"]
+
+logger = Logger("drtsans.instruments")
 
 
 @enum.unique
@@ -200,10 +202,14 @@ def is_time_of_flight(input_query):
     return instrument_enum_name(input_query) is InstrumentEnumName.EQSANS  # we only have one, for the moment
 
 
-def fetch_idf(idf_xml: str, output_directory: str = os.getcwd()):
+def fetch_idf(idf_xml: str, output_directory: str = os.getcwd()) -> str:
     r"""
     Download an IDF from the Mantid GitHub repository to a temporary directory. If the download fails, attempt to
     find the IDF in the local instrument directories and copy to the temporary directory.
+
+    A download is considered failed unless the server responds with HTTP status 200. Checking the status is
+    necessary because an error response body, such as the one served when GitHub rate-limits the request with
+    status 429, would otherwise be written to disk and later rejected by Mantid as malformed XML.
 
     Parameters
     ----------
@@ -215,28 +221,34 @@ def fetch_idf(idf_xml: str, output_directory: str = os.getcwd()):
     -------
     str
         absolute path to the downloaded IDF file.
+
+    Raises
+    ------
+    FileNotFoundError
+        The download failed and the IDF is absent from the local instrument directories.
     """
-
-    def _empty_download(filepath):
-        r"""The curl command may return and exit code of 0, signaling success, yet the file may contain only the
-        string '404: Not Found'. This function checks for this scenario."""
-        return "404: Not Found" in open(filepath).read()
-
     idf = os.path.join(str(output_directory), idf_xml)
     url = f"https://raw.githubusercontent.com/mantidproject/mantid/main/instrument/{idf_xml}"
-    result = subprocess.run(f"curl -o {idf} {url}", shell=True, capture_output=True, text=True, check=False)
-    if result.returncode == 0 and not _empty_download(idf):
-        return idf
+
+    try:
+        response = requests.get(url, timeout=30)
+    except requests.RequestException as error:
+        logger.warning(f"Downloading {idf_xml} failed with error: {error}.")
     else:
-        print(f"Dowloading {idf_xml} failed with error: {result.stderr}.")
-        print("Attempting to find the IDF in the local instrument directories.")
-        local_dirs = config.getInstrumentDirectories()
-        for instrument_directory in local_dirs:
-            idf_local = os.path.join(instrument_directory, idf_xml)
-            if os.path.isfile(idf_local):
-                shutil.copy(idf_local, idf)
-                return idf
-        raise FileNotFoundError(f"IDF {idf_xml} not found in the local instrument directories {local_dirs}.")
+        if response.status_code == 200:
+            with open(idf, "wb") as file_handle:
+                file_handle.write(response.content)
+            return idf
+        logger.warning(f"Downloading {idf_xml} failed with HTTP status {response.status_code}.")
+
+    logger.notice("Attempting to find the IDF in the local instrument directories.")
+    local_dirs = config.getInstrumentDirectories()
+    for instrument_directory in local_dirs:
+        idf_local = os.path.join(instrument_directory, idf_xml)
+        if os.path.isfile(idf_local):
+            shutil.copy(idf_local, idf)
+            return idf
+    raise FileNotFoundError(f"IDF {idf_xml} not found in the local instrument directories {local_dirs}.")
 
 
 def empty_instrument_workspace(

--- a/src/drtsans/tof/eqsans/api.py
+++ b/src/drtsans/tof/eqsans/api.py
@@ -251,6 +251,7 @@ def load_all_files(reduction_input, prefix="", load_params=None, allow_processed
                     time_interval=reduction_config["timeSliceInterval"],
                     time_offset=reduction_config["timeSliceOffset"],
                     time_period=reduction_config["timeSlicePeriod"],
+                    raise_on_empty=True,
                     **load_params_sample,
                 )
             elif logslice:
@@ -260,6 +261,7 @@ def load_all_files(reduction_input, prefix="", load_params=None, allow_processed
                     output_workspace=ws_name,
                     log_name=logslicename,
                     log_value_interval=reduction_config["logSliceInterval"],
+                    raise_on_empty=True,
                     **load_params_sample,
                 )
             for _w in mtd[ws_name]:
@@ -284,7 +286,9 @@ def load_all_files(reduction_input, prefix="", load_params=None, allow_processed
             )
             print(f"Loading filename {filename}")
             filenames.add(filename)
-            loaded_sample_tup = load_events_and_histogram(filename, output_workspace=ws_name, **load_params_sample)
+            loaded_sample_tup = load_events_and_histogram(
+                filename, output_workspace=ws_name, raise_on_empty=True, **load_params_sample
+            )
             sample_bands = loaded_sample_tup.bands
             if default_mask:
                 apply_mask(ws_name, mask=default_mask)

--- a/src/drtsans/tof/eqsans/chopper.py
+++ b/src/drtsans/tof/eqsans/chopper.py
@@ -19,6 +19,7 @@ from mantid.simpleapi import LoadNexusProcessed, mtd
 
 from drtsans.type_hints import EmissionDelay
 from drtsans.wavelength import Wbands
+from drtsans.tof.eqsans.samplelogs import get_frequency
 
 
 class EQSANSDiskChopperSet:
@@ -61,7 +62,7 @@ class EQSANSDiskChopperSet:
         # Determine period and if frame skipping mode from the first chopper
         ch = self._choppers[0]
         # example of frame skipping: chopper speed 30 Hz, pulse frequency 60 Hz: abs(30 - 60) / 2 = 15
-        condition = abs(ch.speed - sample_logs.frequency.value.mean()) / 2 > 1
+        condition = abs(ch.speed - get_frequency(sample_logs)) / 2 > 1
         self.frame_mode = FrameMode.skip if condition else FrameMode.not_skip
 
         # Select appropriate offsets, based on the frame-skip mode.

--- a/src/drtsans/tof/eqsans/correct_frame.py
+++ b/src/drtsans/tof/eqsans/correct_frame.py
@@ -22,6 +22,7 @@ from mantid.simpleapi import (
 )
 from drtsans.samplelogs import SampleLogs
 from drtsans.tof.eqsans.chopper import EQSANSDiskChopperSet
+from drtsans.tof.eqsans.samplelogs import get_frequency
 from drtsans.frame_mode import FrameMode
 from drtsans import wavelength as wlg
 from drtsans.geometry import source_detector_distance
@@ -298,12 +299,8 @@ def transmitted_bands(input_workspace):
         - lead, WBand object for the wavelength band of the lead pulse
         - skipped, Wband for the skipped pulse. None if not operating in the skipped frame mode
     """
-    sample_logs = SampleLogs(input_workspace)
-    try:
-        # 10^6/60 micro-seconds
-        pulse_period = 1.0e6 / sample_logs.single_value("frequency")
-    except RuntimeError:
-        pulse_period = 1.0e6 / 60.0  # reasonable default
+    # 10^6/60 micro-seconds
+    pulse_period = 1.0e6 / get_frequency(input_workspace)
     ch = EQSANSDiskChopperSet(input_workspace)  # object representing the choppers (four or six)
     # Wavelength band of neutrons from the leading pulse transmitted
     # by the chopper system
@@ -572,7 +569,7 @@ def correct_tof_frame(input_workspace, source_to_component_distance, path_to_pix
     """
     ws = mtd[str(input_workspace)]
     sl = SampleLogs(ws)
-    pulse_period = 1.0e6 / sl.frequency.value.mean()  # 10^6/60 micro-seconds
+    pulse_period = 1.0e6 / get_frequency(sl)  # 10^6/60 micro-seconds
     ch = EQSANSDiskChopperSet(ws)  # object representing the choppers (four or six)
     # The TOF values recorded are never bigger than the frame width,
     # which is also the choppers' rotational period.

--- a/src/drtsans/tof/eqsans/load.py
+++ b/src/drtsans/tof/eqsans/load.py
@@ -120,6 +120,8 @@ def load_events(
     output_workspace=None,
     output_suffix="",
     allow_processed_nexus=False,
+    # Disabled by default because auxiliary workspaces may legitimately be empty.
+    raise_on_empty=False,
     **kwargs,
 ):
     r"""
@@ -165,6 +167,8 @@ def load_events(
         When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
         in addition to event Nexus files. This is useful for live reduction where events
         are saved to a temporary file.
+    raise_on_empty: bool
+        Raise an exception when no detector events are loaded.
     kwargs: dict
         Additional positional arguments for :ref:`LoadEventNexus <algm-LoadEventNexus-v1>`.
 
@@ -189,6 +193,14 @@ def load_events(
 
     # EQSANS specific part benefits from converting workspace to a string
     output_workspace = str(output_workspace)
+
+    if raise_on_empty and mtd[output_workspace].getNumberEvents() == 0:
+        raise RuntimeError(
+            f"No detector events were loaded for sample '{run}'. "
+            "The file may contain no detector events, or the requested "
+            "LoadEventNexus filtering excluded all events. Check "
+            "FilterByTimeStart, FilterByTimeStop, and other load options."
+        )
 
     # Correct TOF of detector
     correct_detector_frame(output_workspace, path_to_pixel=path_to_pixel)
@@ -221,6 +233,7 @@ def load_events_and_histogram(
     keep_events=True,
     sample_bands=None,
     allow_processed_nexus=False,
+    raise_on_empty=False,
     **kwargs,
 ):
     r"""Load events from one or more NeXus files with initial corrections
@@ -297,6 +310,8 @@ def load_events_and_histogram(
         When true, allows loading processed Nexus files (e.g., saved with SaveNexusProcessed)
         in addition to event Nexus files. This is useful for live reduction where events
         are saved to a temporary file.
+    raise_on_empty: bool
+        Raise an exception when no detector events are loaded.
     kwargs: dict
         Additional positional arguments for :ref:`LoadEventNexus <algm-LoadEventNexus-v1>`.
 
@@ -337,6 +352,7 @@ def load_events_and_histogram(
             output_workspace=output_workspace,
             output_suffix=output_suffix,
             allow_processed_nexus=allow_processed_nexus,
+            raise_on_empty=raise_on_empty,
             **kwargs,
         )
 
@@ -571,6 +587,7 @@ def load_and_split_and_histogram(
     log_name=None,
     log_value_interval=None,
     reuse_workspace=False,
+    raise_on_empty=False,
     **kwargs,
 ):
     r"""Load an event NeXus file and filter into a WorkspaceGroup depending
@@ -604,6 +621,9 @@ def load_and_split_and_histogram(
         A multiple integer of the time interval. If specified, it indicates that the time
         slicing is periodic so that events in time intervals separated by one (or more) period
         should be reduced together.
+    raise_on_empty: bool
+        Raise an exception when no sliced detector workspaces remain. Empty individual
+        slices are removed and do not cause an exception.
 
     Returns
     -------
@@ -629,6 +649,14 @@ def load_and_split_and_histogram(
         reuse_workspace=reuse_workspace,
         **kwargs,
     )
+
+    if raise_on_empty and ws_group.getNumberOfEntries() == 0:
+        raise RuntimeError(
+            f"No detector events remained for sample '{run}' after slicing. "
+            "Check the requested time/log slice and any LoadEventNexus "
+            "filtering options."
+        )
+
     bands = None
     for _w in ws_group:
         if center_x is None or center_y is None:

--- a/src/drtsans/tof/eqsans/samplelogs.py
+++ b/src/drtsans/tof/eqsans/samplelogs.py
@@ -1,0 +1,39 @@
+"""Helpers for reading EQSANS-specific sample logs."""
+
+from drtsans.samplelogs import SampleLogs
+
+
+DEFAULT_FREQUENCY = 60.0
+FREQUENCY_LOG = "frequency"
+FALLBACK_FREQUENCY_LOG = "BL6:Det:TH:BL:Frequency"
+
+
+def get_frequency(input_workspace) -> float:
+    r"""Return the EQSANS pulse frequency in Hz.
+
+    The primary ``frequency`` log is used when it contains a positive value.
+    Some runs instead contain the detector timing log
+    ``BL6:Det:TH:BL:Frequency``; its positive mean is used when the primary
+    log is missing or zero.  A 60 Hz default is returned when neither log is
+    usable.
+
+    Parameters
+    ----------
+    input_workspace
+        Workspace, run, workspace name, file accepted by :class:`SampleLogs`, or
+        an existing :class:`SampleLogs` instance.
+
+    Returns
+    -------
+    float
+        Mean pulse frequency in Hz.
+    """
+    sample_logs = input_workspace if isinstance(input_workspace, SampleLogs) else SampleLogs(input_workspace)
+    for log_name in (FREQUENCY_LOG, FALLBACK_FREQUENCY_LOG):
+        try:
+            frequency = sample_logs.single_value(log_name)
+        except (AttributeError, KeyError, RuntimeError):
+            continue
+        if frequency > 0.0:
+            return frequency
+    return DEFAULT_FREQUENCY

--- a/src/drtsans/tof/eqsans/samplelogs.py
+++ b/src/drtsans/tof/eqsans/samplelogs.py
@@ -1,5 +1,9 @@
 """Helpers for reading EQSANS-specific sample logs."""
 
+from typing import Union
+
+from mantid.api import MatrixWorkspace, Run
+
 from drtsans.samplelogs import SampleLogs
 
 
@@ -8,7 +12,7 @@ FREQUENCY_LOG = "frequency"
 FALLBACK_FREQUENCY_LOG = "BL6:Det:TH:BL:Frequency"
 
 
-def get_frequency(input_workspace) -> float:
+def get_frequency(input_workspace: Union[str, Run, MatrixWorkspace, SampleLogs]) -> float:
     r"""Return the EQSANS pulse frequency in Hz.
 
     The primary ``frequency`` log is used when it contains a positive value.
@@ -32,7 +36,7 @@ def get_frequency(input_workspace) -> float:
     for log_name in (FREQUENCY_LOG, FALLBACK_FREQUENCY_LOG):
         try:
             frequency = sample_logs.single_value(log_name)
-        except (AttributeError, KeyError, RuntimeError):
+        except (AssertionError, AttributeError, KeyError, RuntimeError):
             continue
         if frequency > 0.0:
             return frequency

--- a/tests/unit/autoreduction/test_reduce_EQSANS.py
+++ b/tests/unit/autoreduction/test_reduce_EQSANS.py
@@ -146,6 +146,18 @@ def test_parse_all_arguments():
     assert args.no_publish is True
 
 
+def test_autoreduce_rejects_empty_event_workspace(tmp_path, mocker):
+    events_file = tmp_path / "EQSANS_186603.nxs.h5"
+    events_file.touch()
+    empty_events = MagicMock()
+    empty_events.getNumberEvents.return_value = 0
+    mocker.patch.object(reduce_EQSANS, "LoadEventNexus", return_value=empty_events)
+
+    args = MagicMock(events_file=str(events_file), outdir=str(tmp_path), no_publish=True)
+    with pytest.raises(RuntimeError, match="has no events after loading with LoadEventNexus"):
+        reduce_EQSANS.autoreduce(args)
+
+
 def test_intensity_array(simulated_events):
     x, y, z = reduce_EQSANS.intensity_array(simulated_events)
     assert z.shape == (reduce_EQSANS.PIXELS_PER_TUBE, reduce_EQSANS.TUBES_IN_DETECTOR1)

--- a/tests/unit/drtsans/test_instruments.py
+++ b/tests/unit/drtsans/test_instruments.py
@@ -17,6 +17,7 @@ from mantid.simpleapi import CreateWorkspace, DeleteWorkspace, LoadEmptyInstrume
 from mantid.kernel import amend_config
 from numpy.testing import assert_almost_equal
 import pytest
+import requests
 from os.path import join as path_join
 
 # standard imports
@@ -125,6 +126,37 @@ def test_copy_to_newest_instrument(fetch_idf, datarepo_dir, clean_workspace):
 def test_fetch_idf(tmpdir):
     instruments_fetch_idf("BIOSANS_Definition_2019_2023.xml", output_directory=tmpdir)
     instruments_fetch_idf("BIOSANS_Definition.xml", output_directory=tmpdir)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        instruments_fetch_idf("nonexisting.xml", output_directory=tmpdir)
+    assert "nonexisting.xml" in str(excinfo.value)
+
+
+def test_fetch_idf_http_error_falls_back_to_local(tmpdir, mocker):
+    r"""A rate-limited download must fall back to the local IDF instead of saving the error response body."""
+    response = mocker.Mock(status_code=429, content=b"429: Too Many Requests")
+    mocker.patch("drtsans.instruments.requests.get", return_value=response)
+
+    idf = instruments_fetch_idf("BIOSANS_Definition.xml", output_directory=tmpdir)
+
+    with open(idf) as file_handle:
+        assert file_handle.read(5) == "<?xml"
+
+
+def test_fetch_idf_network_error_falls_back_to_local(tmpdir, mocker):
+    r"""A connection failure must be handled by the local fallback rather than propagating."""
+    mocker.patch("drtsans.instruments.requests.get", side_effect=requests.ConnectionError("no route to host"))
+
+    idf = instruments_fetch_idf("BIOSANS_Definition.xml", output_directory=tmpdir)
+
+    with open(idf) as file_handle:
+        assert file_handle.read(5) == "<?xml"
+
+
+def test_fetch_idf_http_error_and_no_local_copy(tmpdir, mocker):
+    r"""When the download fails and no local copy exists, the error must name the missing IDF."""
+    response = mocker.Mock(status_code=429, content=b"429: Too Many Requests")
+    mocker.patch("drtsans.instruments.requests.get", return_value=response)
+
     with pytest.raises(FileNotFoundError) as excinfo:
         instruments_fetch_idf("nonexisting.xml", output_directory=tmpdir)
     assert "nonexisting.xml" in str(excinfo.value)

--- a/tests/unit/drtsans/tof/eqsans/test_load.py
+++ b/tests/unit/drtsans/tof/eqsans/test_load.py
@@ -4,7 +4,7 @@ import pytest
 from pytest import approx
 import numpy as np
 
-from mantid.simpleapi import Rebin, SumSpectra, mtd
+from mantid.simpleapi import CreateSampleWorkspace, Rebin, SumSpectra, mtd
 from mantid.kernel import amend_config
 from drtsans.tof.eqsans.load import (
     load_events,
@@ -20,6 +20,38 @@ from drtsans.tof.eqsans.correct_frame import (
     set_init_uncertainties,
 )
 from drtsans.samplelogs import SampleLogs
+
+
+def test_load_events_raises_for_empty_workspace(mocker, clean_workspace):
+    empty_workspace = CreateSampleWorkspace(
+        OutputWorkspace="empty", WorkspaceType="Event", NumBanks=1, BankPixelWidth=1, NumEvents=0
+    )
+    mocker.patch("drtsans.tof.eqsans.load.generic_load_events", return_value="empty")
+
+    with pytest.raises(RuntimeError, match="No detector events were loaded for sample 'sample.nxs'"):
+        load_events("sample.nxs", raise_on_empty=True)
+    clean_workspace(empty_workspace)
+
+
+def test_load_events_does_not_raise_for_empty_workspace_by_default(mocker, clean_workspace):
+    empty_workspace = CreateSampleWorkspace(
+        OutputWorkspace="empty", WorkspaceType="Event", NumBanks=1, BankPixelWidth=1, NumEvents=0
+    )
+    mocker.patch("drtsans.tof.eqsans.load.generic_load_events", return_value="empty")
+    mocker.patch("drtsans.tof.eqsans.load.correct_detector_frame")
+    mocker.patch("drtsans.tof.eqsans.load.correct_emission_time")
+
+    assert load_events("sample.nxs").name() == empty_workspace.name()
+    clean_workspace(empty_workspace)
+
+
+def test_load_and_split_and_histogram_raises_only_when_all_slices_are_empty(mocker):
+    empty_group = mocker.Mock()
+    empty_group.getNumberOfEntries.return_value = 0
+    mocker.patch("drtsans.tof.eqsans.load.load_and_split", return_value=empty_group)
+
+    with pytest.raises(RuntimeError, match="No detector events remained for sample 'sample.nxs' after slicing"):
+        load_and_split_and_histogram("sample.nxs", time_interval=10, raise_on_empty=True)
 
 
 @pytest.mark.datarepo

--- a/tests/unit/drtsans/tof/eqsans/test_samplelogs.py
+++ b/tests/unit/drtsans/tof/eqsans/test_samplelogs.py
@@ -1,0 +1,52 @@
+from mantid.kernel import DateAndTime, FloatTimeSeriesProperty
+from mantid.simpleapi import CreateWorkspace
+import pytest
+
+from drtsans.tof.eqsans.samplelogs import (
+    DEFAULT_FREQUENCY,
+    FALLBACK_FREQUENCY_LOG,
+    FREQUENCY_LOG,
+    get_frequency,
+)
+
+
+def add_frequency_log(workspace, name, values):
+    log = FloatTimeSeriesProperty(name)
+    for index, value in enumerate(values):
+        log.addValue(DateAndTime(f"2020-01-01T00:00:0{index}"), value)
+    workspace.mutableRun().addProperty(name, log, True)
+
+
+def test_get_frequency_returns_primary_mean(clean_workspace):
+    workspace = CreateWorkspace(DataX=[0.0, 1.0], DataY=[1.0])
+    clean_workspace(workspace)
+    add_frequency_log(workspace, FREQUENCY_LOG, [50.0, 70.0])
+    add_frequency_log(workspace, FALLBACK_FREQUENCY_LOG, [30.0, 30.0])
+
+    assert get_frequency(workspace) == pytest.approx(60.0)
+
+
+def test_get_frequency_uses_fallback_when_primary_is_missing(clean_workspace):
+    workspace = CreateWorkspace(DataX=[0.0, 1.0], DataY=[1.0])
+    clean_workspace(workspace)
+    add_frequency_log(workspace, FALLBACK_FREQUENCY_LOG, [50.0, 70.0])
+
+    assert get_frequency(workspace) == pytest.approx(60.0)
+
+
+def test_get_frequency_uses_fallback_when_primary_is_zero(clean_workspace):
+    workspace = CreateWorkspace(DataX=[0.0, 1.0], DataY=[1.0])
+    clean_workspace(workspace)
+    add_frequency_log(workspace, FREQUENCY_LOG, [0.0])
+    add_frequency_log(workspace, FALLBACK_FREQUENCY_LOG, [59.0, 61.0])
+
+    assert get_frequency(workspace) == pytest.approx(60.0)
+
+
+def test_get_frequency_uses_default_when_both_logs_are_unusable(clean_workspace):
+    workspace = CreateWorkspace(DataX=[0.0, 1.0], DataY=[1.0])
+    clean_workspace(workspace)
+    add_frequency_log(workspace, FREQUENCY_LOG, [0.0])
+    add_frequency_log(workspace, FALLBACK_FREQUENCY_LOG, [0.0])
+
+    assert get_frequency(workspace) == pytest.approx(DEFAULT_FREQUENCY)

--- a/tests/unit/drtsans/tof/eqsans/test_samplelogs.py
+++ b/tests/unit/drtsans/tof/eqsans/test_samplelogs.py
@@ -43,6 +43,16 @@ def test_get_frequency_uses_fallback_when_primary_is_zero(clean_workspace):
     assert get_frequency(workspace) == pytest.approx(60.0)
 
 
+def test_get_frequency_uses_fallback_when_primary_is_empty(clean_workspace):
+    workspace = CreateWorkspace(DataX=[0.0, 1.0], DataY=[1.0])
+    clean_workspace(workspace)
+    empty_log = FloatTimeSeriesProperty(FREQUENCY_LOG)
+    workspace.mutableRun().addProperty(FREQUENCY_LOG, empty_log, True)
+    add_frequency_log(workspace, FALLBACK_FREQUENCY_LOG, [59.0, 61.0])
+
+    assert get_frequency(workspace) == pytest.approx(60.0)
+
+
 def test_get_frequency_uses_default_when_both_logs_are_unusable(clean_workspace):
     workspace = CreateWorkspace(DataX=[0.0, 1.0], DataY=[1.0])
     clean_workspace(workspace)


### PR DESCRIPTION
## Description of work:
This PR improves robustness around instrument definition file (IDF) retrieval by treating any non-HTTP-200 download response as a failure and falling back to a local IDF copy. It also introduces EQSANS-specific sample log handling for pulse frequency, updating EQSANS TOF frame-correction logic to use a new `get_frequency()` helper with fallback behavior. Finally, the autoreduction script for EQSANS includes a guard against Nexus files containing no events, which has been observed in some instances.

**Changes:**
- Replace `curl`-based IDF download with `requests.get()` and fall back to local instrument directories unless the response is HTTP 200 (`src/drtsans/instruments.py`), with added unit tests.
- Add `drtsans.tof.eqsans.samplelogs.get_frequency()` to read EQSANS pulse frequency with fallback log support and a default frequency, plus unit tests.
- Update EQSANS frame-correction and chopper code paths to use `get_frequency()` instead of directly reading the `frequency` log.
- 
**Check all that apply:**
- [ ] ~updated documentation and checked that it looks correct in the [pull request preview]~(https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Unit tests added/refactored
- [ ] ~Integration tests added/refactored~
- [ ] Included a manual test for the reviewer
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- ~Links to IBM EWM items:~
- ~Links to related issues or pull requests:~

## :warning: Manual test for the reviewer
in the terminal, at the root of the repository, run:
```python
python ./scripts/autoreduction/reduce_EQSANS.py /SNS/EQSANS/IPTS-38681/nexus/EQSANS_186603.nxs.h5 /tmp/test_186603 --no_publish
```
and verify it exits with error message:
```bash
RuntimeError: File /SNS/EQSANS/IPTS-38681/nexus/EQSANS_186603.nxs.h5 has no events after loading with LoadEventNexus
```

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent

### Execution of tests requiring the /SNS and /HFIR filesystems
It is strongly encouraged that the reviewer runs the "manual" tests in their local machine
because these are not run by the GitLab CI. It is necessary that the remote /SNS and /HFIR filesystems
are mounted in the machine running the tests.
In the below code block, substitute `<MERGE_REQUEST_NUMBER>` for the actual merge request number`


```bash
cd /path/to/my/drtsans/
git fetch origin merge-requests/<MERGE_REQUEST_NUMBER>/head:mr<MERGE_REQUEST_NUMBER>
git switch mr<MERGE_REQUEST_NUMBER>
pixi run manual-test
```
